### PR TITLE
Sending a pull request

### DIFF
--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/PluginImpl.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/PluginImpl.java
@@ -41,7 +41,6 @@ import hudson.security.Permission;
 import hudson.security.PermissionGroup;
 import hudson.util.CopyOnWriteList;
 import net.sf.json.JSONObject;
-import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
 
 import java.io.IOException;
@@ -204,15 +203,8 @@ public class PluginImpl extends Plugin {
      * @return a URL to the image.
      */
     public static String getFullImageUrl(String size, String name) {
-        String contextPath = "";
-        StaplerRequest currentRequest = Stapler.getCurrentRequest();
-        if (currentRequest != null) {
-            contextPath = currentRequest.getContextPath();
-        }
-        if (contextPath.startsWith("/")) {
-            contextPath = contextPath.substring(1);
-        }
-        return Hudson.getInstance().getRootUrl() + contextPath + getImageUrl(size, name);
+        return Hudson.getInstance().getRootUrlFromRequest() + getStaticImagesBase() 
+            + "/" + size + "/" + name;
     }
 
     /**


### PR DESCRIPTION
After the update to version 1.3.0, all icons except the one of the 'Failure Cause Management' menu were no longer shown. This was caused by a duplicate context within the URL, which is fixed with the proposed change.
