### PR TITLE
make failure cause visible via job api

### DIFF
--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCauseBuildAction.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCauseBuildAction.java
@@ -31,6 +31,7 @@ import hudson.model.BuildBadgeAction;
 import hudson.model.Hudson;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.export.*;
 
 import java.util.LinkedList;
 import java.io.IOException;
@@ -43,6 +44,7 @@ import java.util.logging.Logger;
  *
  * @author Tomas Westling &lt;thomas.westling@sonyericsson.com&gt;
  */
+@ExportedBean
 public class FailureCauseBuildAction implements BuildBadgeAction {
     private transient List<FailureCause> failureCauses;
     private List<FoundFailureCause> foundFailureCauses;
@@ -87,6 +89,7 @@ public class FailureCauseBuildAction implements BuildBadgeAction {
      *
      * @return the FoundFailureCauses.
      */
+    @Exported
     public List<FoundFailureCause> getFoundFailureCauses() {
         return foundFailureCauses;
     }

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FoundFailureCause.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FoundFailureCause.java
@@ -25,6 +25,7 @@
 package com.sonyericsson.jenkins.plugins.bfa.model;
 
 import com.sonyericsson.jenkins.plugins.bfa.model.indication.FoundIndication;
+import org.kohsuke.stapler.export.*;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -34,6 +35,7 @@ import java.util.List;
  *
  * @author Tomas Westling &lt;tomas.westling@sonymobile.com&gt;
  */
+@ExportedBean
 public class FoundFailureCause {
     private String id;
     private String name;
@@ -59,6 +61,7 @@ public class FoundFailureCause {
      *
      * @return the id.
      */
+    @Exported
     public String getId() {
         return id;
     }
@@ -68,6 +71,7 @@ public class FoundFailureCause {
      *
      * @return the name.
      */
+    @Exported
     public String getName() {
         return name;
     }
@@ -77,6 +81,7 @@ public class FoundFailureCause {
      *
      * @return the description.
      */
+    @Exported
     public String getDescription() {
         return description;
     }
@@ -86,6 +91,7 @@ public class FoundFailureCause {
      *
      * @return the categories.
      */
+    @Exported
     public List<String> getCategories() {
         return categories;
     }


### PR DESCRIPTION
This change exposes the failure cause data via the Job API so it can be consumed by Jenkins API clients, i.e. for automated data collection/analysis.
