### PR TITLE
Address NPE in getNotScannedBuilds()

### DIFF
--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/sod/ScanOnDemandBaseAction.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/sod/ScanOnDemandBaseAction.java
@@ -170,9 +170,12 @@ public class ScanOnDemandBaseAction implements Action {
         if (project != null) {
             List<AbstractBuild> builds = project.getBuilds();
             for (AbstractBuild build : builds) {
-                if (build.getActions(FailureCauseBuildAction.class).isEmpty()
-                        && build.getActions(FailureCauseMatrixBuildAction.class).isEmpty()
-                        && build.getResult().isWorseThan(Result.SUCCESS)) {
+                final Result result = build.getResult();
+                if (result != null
+                    && result.isWorseThan(Result.SUCCESS)
+                    && build.getActions(FailureCauseBuildAction.class).isEmpty()
+                    && build.getActions(FailureCauseMatrixBuildAction.class).isEmpty()) {
+
                     sodbuilds.add(build);
                 }
             }


### PR DESCRIPTION
From our Jenkins Log:
Caught exception evaluating: it.getBuilds(scanTarget) in /job/job-name/scan-on-demand/. Reason: java.lang.NullPointerException
java.lang.NullPointerException
    at com.sonyericsson.jenkins.plugins.bfa.sod.ScanOnDemandBaseAction.getNotScannedBuilds(ScanOnDemandBaseAction.java:173)
    at com.sonyericsson.jenkins.plugins.bfa.sod.ScanOnDemandBaseAction.getBuilds(ScanOnDemandBaseAction.java:154)
    at com.sonyericsson.jenkins.plugins.bfa.sod.ScanOnDemandBaseAction.getBuilds(ScanOnDemandBaseAction.java:142)
...
