### PR TITLE
Address multiline "Match Text" failure*

### DIFF
--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureReader.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureReader.java
@@ -65,6 +65,16 @@ public abstract class FailureReader {
     }
 
     /**
+     * Scans a build log.
+     *
+     * @param build - the build whose log should be scanned.
+     * @return a FoundIndication if the pattern given by this FailureReader
+     * is found in the log of the given build; return null otherwise.
+     * @throws IOException if so.
+     */
+    public abstract FoundIndication scan(AbstractBuild build) throws IOException;
+
+    /**
      * Scans for indications of a failure cause.
      * @param build the build to scan for indications.
      * @param buildLog the log of the build.

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/indication/BuildLogIndication.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/indication/BuildLogIndication.java
@@ -270,9 +270,8 @@ public class BuildLogIndication extends Indication {
                     }
                     if (build != null) {
                         try {
-                            BuildLogFailureReader buildLogFailureReader =
-                                    new BuildLogFailureReader(new BuildLogIndication(testPattern));
-                            FoundIndication foundIndication = buildLogFailureReader.scan(build);
+                            final FailureReader failureReader = getFailureReader(testPattern);
+                            final FoundIndication foundIndication = failureReader.scan(build);
                             if (foundIndication == null) {
                                 return FormValidation.warning(Messages.StringDoesNotMatchPattern());
                             }
@@ -326,5 +325,12 @@ public class BuildLogIndication extends Indication {
             }
         }
 
+        /**
+         * @param testPattern the test pattern for the indication passed to the failure reader
+         * @return the failure reader corresponding to this descriptor
+         */
+        protected FailureReader getFailureReader(final String testPattern) {
+            return new BuildLogFailureReader(new BuildLogIndication(testPattern));
+        }
     }
 }

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/indication/MultilineBuildLogIndication.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/indication/MultilineBuildLogIndication.java
@@ -75,5 +75,9 @@ public class MultilineBuildLogIndication extends BuildLogIndication {
             return Messages.MultilineBuildLogIndication_DisplayName();
         }
 
+        @Override
+        protected FailureReader getFailureReader(final String testPattern) {
+            return new MultilineBuildLogFailureReader(new MultilineBuildLogIndication(testPattern));
+        }
     }
 }

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureReaderTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureReaderTest.java
@@ -67,6 +67,11 @@ public class FailureReaderTest {
         }
 
         @Override
+        public FoundIndication scan(AbstractBuild build) throws IOException {
+            return null;
+        }
+
+        @Override
         public FoundIndication scan(AbstractBuild build, PrintStream buildLog) {
             return null;
         }

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/model/indication/MultilineBuildLogIndicationTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/model/indication/MultilineBuildLogIndicationTest.java
@@ -117,17 +117,17 @@ public class MultilineBuildLogIndicationTest extends HudsonTestCase {
         String buildUrl = getURL() + freeStyleBuild.getUrl(); // buildUrl will end with /1/
         MultilineBuildLogIndication.MultilineBuildLogIndicationDescriptor indicationDescriptor =
                 new MultilineBuildLogIndication.MultilineBuildLogIndicationDescriptor();
-        FormValidation formValidation = indicationDescriptor.doMatchText(".*teststr.*", buildUrl, true);
+        FormValidation formValidation = indicationDescriptor.doMatchText("teststring.*here", buildUrl, true);
         assertEquals(FIRST_LINE_TEST_STRING, formValidation.getMessage());
         assertEquals(FormValidation.Kind.OK, formValidation.kind);
 
         buildUrl = buildUrl.replace("/1/", "/lastBuild");
-        formValidation = indicationDescriptor.doMatchText(".*teststr.*", buildUrl, true);
+        formValidation = indicationDescriptor.doMatchText("teststring.*here", buildUrl, true);
         assertEquals(FIRST_LINE_TEST_STRING, formValidation.getMessage());
         assertEquals(FormValidation.Kind.OK, formValidation.kind);
 
         buildUrl = buildUrl.replace("lastBuild", "lastSuccessfulBuild");
-        formValidation = indicationDescriptor.doMatchText(".*teststr.*", buildUrl, true);
+        formValidation = indicationDescriptor.doMatchText("teststring.*here", buildUrl, true);
         assertEquals(FIRST_LINE_TEST_STRING, formValidation.getMessage());
         assertEquals(FormValidation.Kind.OK, formValidation.kind);
     }
@@ -148,24 +148,24 @@ public class MultilineBuildLogIndicationTest extends HudsonTestCase {
         String buildUrl = getURL() + build.getUrl();
         MultilineBuildLogIndication.MultilineBuildLogIndicationDescriptor indicationDescriptor =
                 new MultilineBuildLogIndication.MultilineBuildLogIndicationDescriptor();
-        FormValidation formValidation = indicationDescriptor.doMatchText(".*Started by.*", buildUrl, true);
+        FormValidation formValidation = indicationDescriptor.doMatchText("Started by.*", buildUrl, true);
         assertEquals("Started by user SYSTEM", formValidation.getMessage());
         assertEquals(FormValidation.Kind.OK, formValidation.kind);
 
         buildUrl = buildUrl.replace("/1/", "/lastFailedBuild");
-        formValidation = indicationDescriptor.doMatchText(".*Started by.*", buildUrl, true);
+        formValidation = indicationDescriptor.doMatchText("Started by.*", buildUrl, true);
         assertEquals("Started by user SYSTEM", formValidation.getMessage());
         assertEquals(FormValidation.Kind.OK, formValidation.kind);
 
         buildUrl = buildUrl.replace("lastFailedBuild", "lastUnsuccessfulBuild");
-        formValidation = indicationDescriptor.doMatchText(".*Started by.*", buildUrl, true);
+        formValidation = indicationDescriptor.doMatchText("Started by.*", buildUrl, true);
         assertEquals("Started by user SYSTEM", formValidation.getMessage());
         assertEquals(FormValidation.Kind.OK, formValidation.kind);
 
         List<MatrixRun> matrixRuns = build.getRuns();
         for (MatrixRun matrixRun : matrixRuns) {
             buildUrl = getURL() + matrixRun.getUrl();
-            formValidation = indicationDescriptor.doMatchText(".*Simulating.*", buildUrl, true);
+            formValidation = indicationDescriptor.doMatchText("Simulating.*", buildUrl, true);
             assertEquals("Simulating a specific result code FAILURE", formValidation.getMessage());
             assertEquals(FormValidation.Kind.OK, formValidation.kind);
         }


### PR DESCRIPTION
In Failure Cause Management > Failure Cause >
Multi-Line Build Log Indication, a matching
multi-line pattern may show "String does not match pattern"
when it actually matches. These changes address this
error.
