### PR TITLE
[JENKINS-18518] Link into consoleFull*

### DIFF
--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/AnnotationHelper.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/AnnotationHelper.java
@@ -64,7 +64,11 @@ public class AnnotationHelper implements Serializable {
      * @param id the id for the line, to refer to in links.
      */
     public void addFocus(String id) {
-        this.before += "<span id=\"" + id + "\">";
+        // This style should shift the anchor down below the header so that it's visible.
+        // "&nbsp;" may be required to make this work for WebKit-based browsers.
+        this.before += "<a id=\"" + id + "\" style=\""
+            + "display:block;position:relative;top:-2em;visibility:hidden"
+            + "\">&nbsp;</a>";
     }
 
     /**

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/IndicationAnnotator.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/IndicationAnnotator.java
@@ -66,7 +66,6 @@ public class IndicationAnnotator extends ConsoleAnnotator<Object> {
                 AnnotationHelper matchingHelper = helperMap.get(matchingString);
                 if (matchingHelper == null) {
                     matchingHelper = new AnnotationHelper();
-                    matchingHelper.addAfter("</span>");
                 }
                 matchingHelper.addTitle(cause.getName());
                 matchingHelper.addFocus(indication.getMatchingHash() + cause.getId());

--- a/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/model/FailureCauseBuildAction/summary.groovy
+++ b/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/model/FailureCauseBuildAction/summary.groovy
@@ -119,7 +119,7 @@ def displayCauses(cause, indent, links) {
                 br {}
                 cause.getIndications().each { indication ->
                     if (links?.buildUrl != null) {
-                        a(href: "${rootURL}/${links.buildUrl}" + "consoleFull"
+                        a(href: "${rootURL}/${links.buildUrl}" + "consoleFull#" + indication.matchingHash + cause.id
                                 , class: "model-link") {
                             text(_("Indication") + " " + (index++))
                         }

--- a/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/model/FailureCauseMatrixBuildAction/summary.groovy
+++ b/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/model/FailureCauseMatrixBuildAction/summary.groovy
@@ -128,7 +128,7 @@ def displayCauses(cause, run, indent, links) {
                 }
                 br {}
                 cause.getIndications().each { indication ->
-                        a(href: "${rootURL}/${links.buildUrl}" + "consoleFull"
+                        a(href: "${rootURL}/${links.buildUrl}" + "consoleFull#" + indication.matchingHash + cause.id
                                 , class: "model-link") {
                             text(_("Indication") + " " + (index++))
                     }


### PR DESCRIPTION
An indication link now includes the id of the location in the
console output. The destination is shifted down so that it is
not obscured by the jenkins breadcrumb header.

The anchor element CSS is based on http://stackoverflow.com/questions/4996330/changing-default-starting-position-of-anchor
