### PR TITLE
Do not add prefix of context twice when calculating base Url

### DIFF
--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/PluginImpl.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/PluginImpl.java
@@ -43,8 +43,6 @@ import hudson.security.Permission;
 import hudson.security.PermissionGroup;
 import hudson.util.CopyOnWriteList;
 import net.sf.json.JSONObject;
-import hudson.tasks.Mailer;
-import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
 
 import java.io.IOException;
@@ -244,20 +242,7 @@ public class PluginImpl extends Plugin {
      * @return a URL to the image.
      */
     public static String getFullImageUrl(String size, String name) {
-        String url = Mailer.descriptor().getUrl();
-        if (url != null) {
-            String contextPath = "";
-            StaplerRequest currentRequest = Stapler.getCurrentRequest();
-            if (currentRequest != null) {
-                contextPath = currentRequest.getContextPath();
-            }
-            if (contextPath.startsWith("/")) {
-                contextPath = contextPath.substring(1);
-            }
-            return Hudson.getInstance().getRootUrl() + contextPath + getImageUrl(size, name);
-        }
-        return Hudson.getInstance().getRootUrlFromRequest() + getStaticImagesBase()
-                + "/" + size + "/" + name;
+        return Hudson.getInstance().getRootUrl() + getImageUrl(size, name);
     }
 
     /**


### PR DESCRIPTION
We have the problem that the images of the plugin is not showing in the UI. We have Jenkins runnning under the /ci prefix and configured this as Jenkins URL on the configuration page.
This change should fix the problem.
