### PR TITLE
Returning found builds

### DIFF
--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/dbf/CoreDBF.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/dbf/CoreDBF.java
@@ -70,6 +70,6 @@ public class CoreDBF extends DownstreamBuildFinder {
             }
         }
 
-        return EMPTY;
+        return foundBuilds;
     }
 }


### PR DESCRIPTION
Looked at the code for getting downstream builds and found this method that did not return anything, ever. Changed the returned statement to the way I think it should be. Have not tested the code.