### PR TITLE
[FIXED JENKINS-24434] fix trim() usage

### DIFF
--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/IndicationAnnotator.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/IndicationAnnotator.java
@@ -77,7 +77,7 @@ public class IndicationAnnotator extends ConsoleAnnotator<Object> {
 
     @Override
     public ConsoleAnnotator annotate(Object context, MarkupText text) {
-        AnnotationHelper match = helperMap.get(text.getText().trim());
+        AnnotationHelper match = helperMap.get(text.getText().replace("\n", "").replace("\r", ""));
         if (match != null) {
             text.wrapBy(match.getBefore(), match.getAfter());
         }


### PR DESCRIPTION
bug 24434 is caused by removal of all whitespace by trim() function. it looks like only eol character removal was intended.

fix tested & verified with jenkins 1.528.
