### PR TITLE
Configurable anonymous access to the list of failure causes

### DIFF
--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/CauseManagement.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/CauseManagement.java
@@ -115,7 +115,8 @@ public class CauseManagement extends BfaGraphAction {
 
     @Override
     public String getIconFileName() {
-        if (Hudson.getInstance().hasPermission(PluginImpl.UPDATE_PERMISSION)) {
+        if (Hudson.getInstance().hasPermission(PluginImpl.UPDATE_PERMISSION) ||
+                Hudson.getInstance().hasPermission(PluginImpl.VIEW_PERMISSION)) {
             return PluginImpl.getDefaultIcon();
         } else {
             return null;
@@ -126,6 +127,8 @@ public class CauseManagement extends BfaGraphAction {
     public String getDisplayName() {
         if (Hudson.getInstance().hasPermission(PluginImpl.UPDATE_PERMISSION)) {
             return Messages.CauseManagement_DisplayName();
+        } else if (Hudson.getInstance().hasPermission(PluginImpl.VIEW_PERMISSION)) {
+            return Messages.CauseList_DisplayName();
         } else {
             return null;
         }

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/CauseManagement.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/CauseManagement.java
@@ -115,8 +115,8 @@ public class CauseManagement extends BfaGraphAction {
 
     @Override
     public String getIconFileName() {
-        if (Hudson.getInstance().hasPermission(PluginImpl.UPDATE_PERMISSION) ||
-                Hudson.getInstance().hasPermission(PluginImpl.VIEW_PERMISSION)) {
+        if (Hudson.getInstance().hasPermission(PluginImpl.UPDATE_PERMISSION)
+                || Hudson.getInstance().hasPermission(PluginImpl.VIEW_PERMISSION)) {
             return PluginImpl.getDefaultIcon();
         } else {
             return null;

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/PluginImpl.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/PluginImpl.java
@@ -87,6 +87,13 @@ public class PluginImpl extends Plugin {
                     Messages._PermissionUpdate_Description(), Hudson.ADMINISTER);
 
     /**
+     * Permission to view the causes. E.e. Access {@link CauseManagement}.
+     */
+    public static final Permission VIEW_PERMISSION =
+            new Permission(PERMISSION_GROUP, "ViewCauses",
+                    Messages._PermissionView_Description(), UPDATE_PERMISSION);
+
+    /**
      * Permission to remove causes.
      */
     public static final Permission REMOVE_PERMISSION =

--- a/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/CauseManagement/index.groovy
+++ b/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/CauseManagement/index.groovy
@@ -32,7 +32,7 @@ def f = namespace(lib.FormTagLib)
 def l = namespace(lib.LayoutTagLib)
 def j = namespace(lib.JenkinsTagLib)
 
-l.layout() {
+l.layout(permission: PluginImpl.VIEW_PERMISSION) {
   l.header(title: _("Failure Cause Management - Confirm Remove"))
 
   def management = CauseManagement.getInstance();

--- a/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/CauseManagement/index.groovy
+++ b/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/CauseManagement/index.groovy
@@ -32,7 +32,7 @@ def f = namespace(lib.FormTagLib)
 def l = namespace(lib.LayoutTagLib)
 def j = namespace(lib.JenkinsTagLib)
 
-l.layout(permission: PluginImpl.UPDATE_PERMISSION) {
+l.layout() {
   l.header(title: _("Failure Cause Management - Confirm Remove"))
 
   def management = CauseManagement.getInstance();
@@ -55,7 +55,11 @@ l.layout(permission: PluginImpl.UPDATE_PERMISSION) {
             + "z-index: -100;"
             + "background-image: url(\'" + bgImageUrl + "');") {}
 
-    h1(_("Update Failure Causes"))
+    if (h.hasPermission(PluginImpl.UPDATE_PERMISSION)) {
+      h1(_("Update Failure Causes"))
+    } else {
+      h1(_("List of Failure Causes"))
+    }
 
     def shallowCauses = management.getShallowCauses()
     if (management.isError(request)) {
@@ -73,28 +77,30 @@ l.layout(permission: PluginImpl.UPDATE_PERMISSION) {
     }
 
     //The New Cause link
-    div(style: "margin-top: 10px; margin-bottom: 10px; width: 90%;") {
-      a(style:  "font-weight: bold; "
-                + "font-size: larger; "
-                + "padding-left: 30px; "
-                + "min-height: 30px; "
-                + "padding-top: 5px; "
-                + "padding-bottom: 5px; "
-                + "background-image: url( \'" + newImageUrl + "\'); "
-                + "background-position: left center; "
-                + "background-repeat: no-repeat;",
-        href: "new",
-        alt: _("New")) {text(_("Create new"))}
+    if (h.hasPermission(PluginImpl.UPDATE_PERMISSION)) {
+        div(style: "margin-top: 10px; margin-bottom: 10px; width: 90%;") {
+            a(style: "font-weight: bold; "
+                    + "font-size: larger; "
+                    + "padding-left: 30px; "
+                    + "min-height: 30px; "
+                    + "padding-top: 5px; "
+                    + "padding-bottom: 5px; "
+                    + "background-image: url( \'" + newImageUrl + "\'); "
+                    + "background-position: left center; "
+                    + "background-repeat: no-repeat;",
+                    href: "new",
+                    alt: _("New")) { text(_("Create new")) }
 
-      if (PluginImpl.getInstance().isGraphsEnabled()) {
-        a(style:  "font-weight: bold; "
-                + "font-size: larger; "
-                + "padding-top: 5px; "
-                + "padding-bottom: 5px; "
-                + "float: right;",
-          href: "detailedgraphs",
-          alt: _("Graphs/statistics")) {text(_("Graphs/Statistics"))}
-      }
+            if (PluginImpl.getInstance().isGraphsEnabled()) {
+                a(style: "font-weight: bold; "
+                        + "font-size: larger; "
+                        + "padding-top: 5px; "
+                        + "padding-bottom: 5px; "
+                        + "float: right;",
+                        href: "detailedgraphs",
+                        alt: _("Graphs/statistics")) { text(_("Graphs/Statistics")) }
+            }
+        }
     }
 
     //One time check so we don't do it for every iteration below
@@ -118,7 +124,11 @@ l.layout(permission: PluginImpl.UPDATE_PERMISSION) {
       shallowCauses.each{ cause ->
         tr {
           td{
-            a(href: cause.getId()){ text(cause.getName())}
+            if (h.hasPermission(PluginImpl.UPDATE_PERMISSION)) {
+              a(href: cause.getId()) { text(cause.getName()) }
+            } else {
+              text(cause.getName())
+            }
           }
           td{
             text(cause.getCategoriesAsString())

--- a/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/Messages.properties
+++ b/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/Messages.properties
@@ -1,10 +1,12 @@
 #I18n messages.
 PermissionGroup_Title=Build Failure Analyzer
+PermissionView_Description=View Failure causes.
 PermissionUpdate_Description=Add and Update Failure causes.
 PermissionRemove_Description=Remove Failure causes.
 BuildLogIndication_DisplayName=Build Log Indication
 MultilineBuildLogIndication_DisplayName=Multi-Line Build Log Indication
 CauseManagement_DisplayName=Failure Cause Management
+CauseList_DisplayName=Failure Causes
 ScannerJobProperty_DisplayName=Do not Scan failed builds
 LocalFileKnowledgeBase_DisplayName=Jenkins Local
 MongoDBKnowledgeBase_DisplayName=Mongo DB

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/CauseManagementPermissionTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/CauseManagementPermissionTest.java
@@ -1,0 +1,61 @@
+package com.sonyericsson.jenkins.plugins.bfa;
+
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import hudson.model.Hudson;
+import hudson.security.GlobalMatrixAuthorizationStrategy;
+import hudson.security.SecurityRealm;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+/**
+ * Tests the permissions for the Cause Management.
+ *
+ * @author Damien Coraboeuf
+ */
+public class CauseManagementPermissionTest {
+
+    /**
+     * The Jenkins Rule.
+     */
+    @Rule
+    //CS IGNORE VisibilityModifier FOR NEXT 1 LINES. REASON: Jenkins Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Before
+    public void jenkinsConfiguration() {
+        SecurityRealm securityRealm = j.createDummySecurityRealm();
+        j.getInstance().setSecurityRealm(securityRealm);
+
+        GlobalMatrixAuthorizationStrategy authorizationStrategy = new GlobalMatrixAuthorizationStrategy();
+        authorizationStrategy.add(Hudson.READ, "anonymous");
+        authorizationStrategy.add(PluginImpl.VIEW_PERMISSION, "view");
+        authorizationStrategy.add(PluginImpl.UPDATE_PERMISSION, "update");
+        authorizationStrategy.add(PluginImpl.VIEW_PERMISSION, "all");
+        authorizationStrategy.add(PluginImpl.UPDATE_PERMISSION, "all");
+        j.getInstance().setAuthorizationStrategy(authorizationStrategy);
+    }
+
+    @Test
+    public void notAllowedToUpdateCausesWhenNotGrantedAnything() throws Exception {
+        JenkinsRule.WebClient webClient = j.createWebClient();
+        // Logs in
+        webClient.goTo("");
+        webClient.login("none");
+        // Gets to the Failure Cause page
+        webClient.goTo("failure-cause-management");
+        // FIXME Expects a failure
+    }
+
+    @Test
+    public void allowedToUpdateCausesWhenGrantedOnlyUpdate() throws Exception {
+        JenkinsRule.WebClient webClient = j.createWebClient();
+        // Logs in
+        webClient.goTo("");
+        webClient.login("update");
+        // Gets to the Failure Cause page
+        HtmlPage page = webClient.goTo("failure-cause-management");
+        // FIXME Checks the "Create New" button is available
+    }
+}


### PR DESCRIPTION
In some contexts, it is interesting to provide authorised users a read-only access to list of failure causes.

This pull request creates a new `ViewCauses` permission, granted automatically for users having already `UpdateCauses`. When a user has this `ViewCauses` permission granted, he can access the list of existing failures.

Best regards,
Damien.