### PR TITLE
Having the token expand into some text when no failure cause is identified

### DIFF
--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/tokens/Token.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/tokens/Token.java
@@ -86,6 +86,11 @@ public class Token extends DataBoundTokenMacro {
     private int wrapWidth = 0;
 
     /**
+     * Default text to include if no problem was found. It defaults to an empty string.
+     */
+    private String noFailureText = "";
+
+    /**
      * @param includeIndications When true, the indication numbers and links into the console log are included
      * in the token replacement text.
      */
@@ -119,6 +124,14 @@ public class Token extends DataBoundTokenMacro {
         this.wrapWidth = wrapWidth;
     }
 
+    /**
+     * @param noFailureText Text to return when no failure cause is present.
+     */
+    @Parameter
+    public void setNoFailureText(final String noFailureText) {
+        this.noFailureText = noFailureText;
+    }
+
     @Override
     public boolean acceptsMacroName(final String macroName) {
         return "BUILD_FAILURE_ANALYZER".equals(macroName);
@@ -135,7 +148,7 @@ public class Token extends DataBoundTokenMacro {
             final FailureCauseDisplayData data = action.getFailureCauseDisplayData();
             if (data.getFoundFailureCauses().isEmpty() && data.getDownstreamFailureCauses().isEmpty()) {
                 logger.info("there were no causes");
-                return "";
+                return noFailureText;
             }
             final StringBuilder stringBuilder = new StringBuilder();
             addTitle(stringBuilder);

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/tokens/TokenTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/tokens/TokenTest.java
@@ -165,4 +165,57 @@ public class TokenTest extends HudsonTestCase {
         assertEquals(expectedWrapAt35LineCount, wrappedAt35.size());
     }
 
+    /**
+     * Tests the expansion when there is no failure for the default setup.
+     *
+     * @throws Exception If necessary
+     */
+    @Test
+    public void testNoFailureWithDefaultEmptyText() throws Exception {
+        // CS IGNORE MagicNumberCheck FOR NEXT 7 LINES. REASON: Test data.
+        final FreeStyleProject project = createFreeStyleProject();
+        project.getBuildersList().add(new PrintToLogBuilder(ERROR));
+        project.getBuildersList().add(new MockBuilder(Result.FAILURE));
+        final Future<FreeStyleBuild> noCauseBuildFuture = project.scheduleBuild2(0);
+        final FreeStyleBuild noCauseBuild = noCauseBuildFuture.get(10, TimeUnit.SECONDS);
+        final String defaultNoResult = TokenMacro.expandAll(noCauseBuild, listener, "${BUILD_FAILURE_ANALYZER}");
+        assertEquals("", defaultNoResult);
+    }
+
+    /**
+     * Tests the expansion when there is no failure with noFailureText set to the empty string.
+     *
+     * @throws Exception If necessary
+     */
+    @Test
+    public void testNoFailureWithEmptyText() throws Exception {
+        // CS IGNORE MagicNumberCheck FOR NEXT 8 LINES. REASON: Test data.
+        final FreeStyleProject project = createFreeStyleProject();
+        project.getBuildersList().add(new PrintToLogBuilder(ERROR));
+        project.getBuildersList().add(new MockBuilder(Result.FAILURE));
+        final Future<FreeStyleBuild> noCauseBuildFuture = project.scheduleBuild2(0);
+        final FreeStyleBuild noCauseBuild = noCauseBuildFuture.get(10, TimeUnit.SECONDS);
+        final String defaultNoResult = TokenMacro.expandAll(noCauseBuild, listener,
+                "${BUILD_FAILURE_ANALYZER, noFailureText=\"\"}");
+        assertEquals("", defaultNoResult);
+    }
+
+    /**
+     * Tests the expansion when there is no failure with noFailureText set to something.
+     *
+     * @throws Exception If necessary
+     */
+    @Test
+    public void testNoFailureWithText() throws Exception {
+        // CS IGNORE MagicNumberCheck FOR NEXT 8 LINES. REASON: Test data.
+        final FreeStyleProject project = createFreeStyleProject();
+        project.getBuildersList().add(new PrintToLogBuilder(ERROR));
+        project.getBuildersList().add(new MockBuilder(Result.FAILURE));
+        final Future<FreeStyleBuild> noCauseBuildFuture = project.scheduleBuild2(0);
+        final FreeStyleBuild noCauseBuild = noCauseBuildFuture.get(10, TimeUnit.SECONDS);
+        final String defaultNoResult = TokenMacro.expandAll(noCauseBuild, listener,
+                "${BUILD_FAILURE_ANALYZER, noFailureText=\"Sample text with <b>html</b>\"}");
+        assertEquals("Sample text with <b>html</b>", defaultNoResult);
+    }
+
 }


### PR DESCRIPTION
When I generate a mail using the `${BUILD_FAILURE_ANALYZER}` token, I want to have the possibility to display some specific text when no failure has been identified.

I have added the optional `noFailureText` option to the token for this purpose, with a default value set to empty.

When using `${BUILD_FAILURE_ANALYSER, noFailureText="No problem has been identified. Please contact xxx for more information"}`, the macro will expand into _No problem has been identified. Please contact xxx for more information_ if no failure has been identified.