### PR TITLE
Prevent breakage involving build-flow plugin

### DIFF
--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/dbf/BuildFlowDBF.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/dbf/BuildFlowDBF.java
@@ -30,6 +30,7 @@ import hudson.model.AbstractBuild;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.logging.Logger;
 
@@ -68,6 +69,8 @@ public class BuildFlowDBF extends DownstreamBuildFinder {
             } catch (ExecutionException e) {
                 // skip
             } catch (InterruptedException e) {
+                // ignore
+            } catch (CancellationException e) {
                 // ignore
             }
         }


### PR DESCRIPTION
In certain cases, the Build Flow plugin can return a CancellationExcpetion
when iterating over downstream builds.

This has the effect of breaking both the Job and Build UIs.

This PR protects against this and [FIXES JENKINS-25396]

It is also related to JENKINS-32144 and JENKINS-25092