### PR TITLE
Add displayName to stored statistics

### DIFF
--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/db/MongoDBKnowledgeBase.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/db/MongoDBKnowledgeBase.java
@@ -467,6 +467,7 @@ public class MongoDBKnowledgeBase extends KnowledgeBase {
         DBObject object = new BasicDBObject();
         object.put("projectName", stat.getProjectName());
         object.put("buildNumber", stat.getBuildNumber());
+        object.put("displayName", stat.getDisplayName());
         object.put("master", stat.getMaster());
         object.put("slaveHostName", stat.getSlaveHostName());
         object.put("startingTime", stat.getStartingTime());

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/statistics/Statistics.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/statistics/Statistics.java
@@ -41,6 +41,7 @@ public class Statistics {
 
     private String projectName;
     private int buildNumber;
+    private String displayName;
     private Date startingTime;
     private long duration;
     private List<String> triggerCauses;
@@ -65,6 +66,14 @@ public class Statistics {
      */
     public int getBuildNumber() {
         return buildNumber;
+    }
+
+    /**
+     * Getter for the build display name.
+     * @return the build display name.
+     */
+    public String getDisplayName() {
+        return displayName;
     }
 
      /**
@@ -159,6 +168,7 @@ public class Statistics {
     @JsonCreator
     public Statistics(@JsonProperty("projectName")    String projectName,
                       @JsonProperty("buildNumber")    int buildNumber,
+                      @JsonProperty("displayName")    String displayName,
                       @JsonProperty("startingTime")   Date startingTime,
                       @JsonProperty("duration")       long duration,
                       @JsonProperty("triggerCauses")  List<String> triggerCauses,
@@ -170,6 +180,7 @@ public class Statistics {
                       @JsonProperty("failureCauses")  List<FailureCauseStatistics> failureCauseStatistics) {
         this.projectName = projectName;
         this.buildNumber = buildNumber;
+        this.displayName = displayName;
         if (startingTime == null) {
             this.startingTime = null;
         } else {
@@ -209,7 +220,7 @@ public class Statistics {
                       int timeZoneOffset,
                       String result,
                       List<FailureCauseStatistics> failureCauseStatistics) {
-        this(projectName, buildNumber, startingTime, duration, triggerCauses, nodeName, master, timeZoneOffset,
+        this(projectName, buildNumber, null, startingTime, duration, triggerCauses, nodeName, master, timeZoneOffset,
              result, null, failureCauseStatistics);
     }
 

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/statistics/Statistics.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/statistics/Statistics.java
@@ -155,6 +155,7 @@ public class Statistics {
      * Standard/JSON constructor.
      * @param projectName the project name.
      * @param buildNumber the build number.
+     * @param displayName the build display name.
      * @param startingTime the starting time.
      * @param duration the duration.
      * @param triggerCauses the causes that triggered this build.

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/statistics/StatisticsLogger.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/statistics/StatisticsLogger.java
@@ -116,6 +116,7 @@ public final class StatisticsLogger {
         public void run() {
             String projectName = build.getProject().getFullName();
             int buildNumber = build.getNumber();
+            String displayName = build.getDisplayName();
             Date startingTime = build.getTime();
             long duration = build.getDuration();
             List<String> triggerCauses = new LinkedList<String>();
@@ -139,8 +140,9 @@ public final class StatisticsLogger {
             master = BfaUtils.getMasterName();
             Cause.UpstreamCause uc = (Cause.UpstreamCause)build.getCause(Cause.UpstreamCause.class);
             Statistics.UpstreamCause suc = new Statistics.UpstreamCause(uc);
-            Statistics obj = new Statistics(projectName, buildNumber, startingTime, duration, triggerCauses, nodeName,
-                                            master, timeZoneOffset, result, suc, failureCauseStatistics);
+            Statistics obj = new Statistics(projectName, buildNumber, displayName, startingTime, duration,
+                                            triggerCauses, nodeName, master, timeZoneOffset, result, suc,
+                                            failureCauseStatistics);
 
             PluginImpl p = PluginImpl.getInstance();
             KnowledgeBase kb = p.getKnowledgeBase();

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/db/EmbeddedMongoStatisticsTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/db/EmbeddedMongoStatisticsTest.java
@@ -443,7 +443,8 @@ public class EmbeddedMongoStatisticsTest extends EmbeddedMongoTest {
         List<FailureCauseStatistics> statList = new ArrayList<FailureCauseStatistics>();
         statList.add(causeStats);
 
-        Statistics statistics1 = new Statistics(null, 1, null, new Date(), 1L, null, null, null, 0, null, null, statList);
+        Statistics statistics1 = new Statistics(null, 1, null, new Date(), 1L, null, null, null, 0, null, null,
+                                                statList);
         Statistics statistics2 = new Statistics(null, 2, null, new Date(), 1L, null, null, null, 0, null, null, null);
 
         knowledgeBase.saveStatistics(statistics1);

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/db/EmbeddedMongoStatisticsTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/db/EmbeddedMongoStatisticsTest.java
@@ -139,11 +139,11 @@ public class EmbeddedMongoStatisticsTest extends EmbeddedMongoTest {
 
         List<FailureCauseStatistics> failureList3 = new ArrayList<FailureCauseStatistics>();
 
-        Statistics statistics1 = new Statistics(PROJECT_A, 1, lastHour, 1L, null, null, MASTER_A, 0, UNSTABLE,
+        Statistics statistics1 = new Statistics(PROJECT_A, 1, "", lastHour, 1L, null, null, MASTER_A, 0, UNSTABLE,
                                                 null, failureList1);
-        Statistics statistics2 = new Statistics(PROJECT_B, 2, now, 1L, null, null, MASTER_B, 0, ABORTED,
+        Statistics statistics2 = new Statistics(PROJECT_B, 2, "", now, 1L, null, null, MASTER_B, 0, ABORTED,
                                                 null, failureList2);
-        Statistics statistics3 = new Statistics(PROJECT_C, 3, now, 1L, null, null, MASTER_C, 0, SUCCESS,
+        Statistics statistics3 = new Statistics(PROJECT_C, 3, "", now, 1L, null, null, MASTER_C, 0, SUCCESS,
                                                 null, failureList3);
 
         knowledgeBase.saveStatistics(statistics1);
@@ -202,7 +202,7 @@ public class EmbeddedMongoStatisticsTest extends EmbeddedMongoTest {
     public void testGetNbrOfNullFailureCauses() throws Exception {
         assertEquals(0, knowledgeBase.getNbrOfNullFailureCauses(null));
 
-        Statistics nullStatistics = new Statistics(null, 1, null, 1L, null, null, null, 1, null, null, null);
+        Statistics nullStatistics = new Statistics(null, 1, null, null, 1L, null, null, null, 1, null, null, null);
         knowledgeBase.saveStatistics(nullStatistics);
 
         assertEquals(1, knowledgeBase.getNbrOfNullFailureCauses(null));
@@ -272,7 +272,7 @@ public class EmbeddedMongoStatisticsTest extends EmbeddedMongoTest {
     @Test
     public void testStatisticsWithUpstreamCauses() throws Exception {
         Statistics.UpstreamCause uc = new UpstreamCause(PROJECT_B, BUILD_NR);
-        Statistics s = new Statistics(PROJECT_A, 1, null, 1L, null, null, MASTER_A, 0, UNSTABLE, uc, null);
+        Statistics s = new Statistics(PROJECT_A, 1, null, null, 1L, null, null, MASTER_A, 0, UNSTABLE, uc, null);
         knowledgeBase.saveStatistics(s);
         List<Statistics> fetchedStatistics = knowledgeBase.getStatistics(null, -1);
         assertNotNull("The fetched statistics should not be null", fetchedStatistics);
@@ -289,7 +289,7 @@ public class EmbeddedMongoStatisticsTest extends EmbeddedMongoTest {
      */
     @Test
     public void testStatisticsWithNoUpstreamCauses() throws Exception {
-        Statistics s = new Statistics(PROJECT_A, 1, null, 1L, null, null, MASTER_A, 0, UNSTABLE, null, null);
+        Statistics s = new Statistics(PROJECT_A, 1, null, null, 1L, null, null, MASTER_A, 0, UNSTABLE, null, null);
         knowledgeBase.saveStatistics(s);
         List<Statistics> fetchedStatistics = knowledgeBase.getStatistics(null, -1);
         assertNotNull("The fetched statistics should not be null", fetchedStatistics);
@@ -443,8 +443,8 @@ public class EmbeddedMongoStatisticsTest extends EmbeddedMongoTest {
         List<FailureCauseStatistics> statList = new ArrayList<FailureCauseStatistics>();
         statList.add(causeStats);
 
-        Statistics statistics1 = new Statistics(null, 1, new Date(), 1L, null, null, null, 0, null, null, statList);
-        Statistics statistics2 = new Statistics(null, 2, new Date(), 1L, null, null, null, 0, null, null, null);
+        Statistics statistics1 = new Statistics(null, 1, null, new Date(), 1L, null, null, null, 0, null, null, statList);
+        Statistics statistics2 = new Statistics(null, 2, null, new Date(), 1L, null, null, null, 0, null, null, null);
 
         knowledgeBase.saveStatistics(statistics1);
         knowledgeBase.saveStatistics(statistics2);

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/db/MongoDBKnowledgeBaseTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/db/MongoDBKnowledgeBaseTest.java
@@ -92,7 +92,7 @@ public class MongoDBKnowledgeBaseTest {
         indications.add(indication);
         mockedCause = new FailureCause("id", "myFailureCause", "description", "comment", new Date(),
                 "category", indications, null);
-        mockedStatistics = new Statistics("projectName", 1, null, 1, null, "nodeName", "master", 0, "result",
+        mockedStatistics = new Statistics("projectName", 1, "", null, 1, null, "nodeName", "master", 0, "result",
                 null, null);
     }
 


### PR DESCRIPTION
I often use a build/run's displayName property to store additional information about the build, like the full version number of the project being built. This information would be nice to have stored in MongoDB along with all of the other build information that is stored.