### PR TITLE
General code quality fix-2

### DIFF
--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/CauseManagement.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/CauseManagement.java
@@ -54,7 +54,6 @@ import java.io.IOException;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Map;
-import java.util.logging.Logger;
 
 /**
  * Page for managing the failure causes.
@@ -63,8 +62,6 @@ import java.util.logging.Logger;
  */
 @Extension
 public class CauseManagement extends BfaGraphAction {
-
-    private static final Logger logger = Logger.getLogger(CauseManagement.class.getName());
 
     /**
      * Where in the Jenkins name space this action will be.

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/graphs/TimeSeriesChart.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/graphs/TimeSeriesChart.java
@@ -153,9 +153,7 @@ public class TimeSeriesChart extends BFAGraph {
 
         plot.setRangeAxis(yAxis);
 
-        JFreeChart chart = new JFreeChart(graphTitle, JFreeChart.DEFAULT_TITLE_FONT, plot, true);
-
-        return chart;
+        return new JFreeChart(graphTitle, JFreeChart.DEFAULT_TITLE_FONT, plot, true);
     }
 
     /**

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCauseColumn.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCauseColumn.java
@@ -119,8 +119,7 @@ public class FailureCauseColumn extends ListViewColumn {
     if (lastBuild == null) {
       return null;
     }
-    FailureCauseBuildAction action = lastBuild.getAction(FailureCauseBuildAction.class);
-    return action;
+    return lastBuild.getAction(FailureCauseBuildAction.class);
   }
 
 }

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/dbf/BuildFlowDBF.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/dbf/BuildFlowDBF.java
@@ -32,7 +32,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
-import java.util.logging.Logger;
 
 
 /**
@@ -43,8 +42,6 @@ import java.util.logging.Logger;
 @Extension
 public class BuildFlowDBF extends DownstreamBuildFinder {
 
-    private static final Logger logger = Logger.
-            getLogger(BuildFlowDBF.class.getName());
     @Override
     public List<AbstractBuild<?, ?>> getDownstreamBuilds(
             final AbstractBuild build) {

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/sod/ScanOnDemandTask.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/sod/ScanOnDemandTask.java
@@ -90,7 +90,6 @@ public class ScanOnDemandTask implements Runnable {
     public void endMatrixBuildScan() throws IOException {
         List<MatrixRun> runs = ((MatrixBuild)build).getRuns();
         List<MatrixRun> runsWithCorrectNumber = new LinkedList<MatrixRun>();
-        int i = 0;
         for (MatrixRun run : runs) {
             if (run.getNumber() == build.getNumber()) {
                 runsWithCorrectNumber.add(run);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1481 - Unused local variables should be removed.
squid:S1068 - Unused private fields should be removed.
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1481
https://dev.eclipse.org/sonar/rules/show/squid:S1068
https://dev.eclipse.org/sonar/rules/show/squid:S1488

Please let me know if you have any questions.

Faisal Hameed