### PR TITLE
General code quality fix-3

### DIFF
--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/CauseManagement.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/CauseManagement.java
@@ -109,7 +109,7 @@ public class CauseManagement extends BfaGraphAction {
     private static final String GRAPH_TITLE_CATEGORIES = "Failures causes for all nodes grouped by categories";
 
     private static final String GRAPH_TITLE_UNKNOWN_PERCENTAGE = "Unknown failure causes";
-
+    private static final String OWNER_URL = "/";
     @Override
     public String getIconFileName() {
         if (Hudson.getInstance().hasPermission(PluginImpl.UPDATE_PERMISSION)
@@ -260,7 +260,7 @@ public class CauseManagement extends BfaGraphAction {
      * @return the owner's URL or some place else to redirect the user after save.
      */
     protected String getOwnerUrl() {
-        return "/";
+        return OWNER_URL;
     }
 
     /**

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/db/KnowledgeBase.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/db/KnowledgeBase.java
@@ -51,6 +51,8 @@ import java.util.Map;
  */
 public abstract class KnowledgeBase implements Describable<KnowledgeBase>, Serializable {
 
+    private static final long DEFAULT_NBR_OF_NULL_FAILURE_CAUSES = 0;
+
     /**
      * Get the list of {@link FailureCause}s. It is intended to be used in the scanning phase hence it should be
      * returned as quickly as possible, so the list could be cached.
@@ -253,7 +255,7 @@ public abstract class KnowledgeBase implements Describable<KnowledgeBase>, Seria
      * @return number of statistics posts without FailureCause
      */
     public long getNbrOfNullFailureCauses(GraphFilterBuilder filter) {
-        return 0;
+        return DEFAULT_NBR_OF_NULL_FAILURE_CAUSES;
     }
 
     /**

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/sod/ScanOnDemandBaseAction.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/sod/ScanOnDemandBaseAction.java
@@ -192,7 +192,7 @@ public class ScanOnDemandBaseAction implements Action {
     public List<AbstractBuild> getBuilds() {
         buildType = getBuildType();
         if (buildType != null) {
-            if (buildType.length() == 0 | buildType.equals(NON_SCANNED)) {
+            if (buildType.length() == 0 || buildType.equals(NON_SCANNED)) {
                 return getNotScannedBuilds();
             } else {
                 return getAllBuilds();

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/utils/OldDataConverter.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/utils/OldDataConverter.java
@@ -28,6 +28,7 @@ import com.sonyericsson.jenkins.plugins.bfa.model.FailureCauseBuildAction;
 import com.sonyericsson.jenkins.plugins.bfa.model.FailureCauseMatrixBuildAction;
 import com.sonyericsson.jenkins.plugins.bfa.model.FoundFailureCause;
 import com.sonyericsson.jenkins.plugins.bfa.model.indication.FoundIndication;
+
 import hudson.Extension;
 import hudson.model.AbstractBuild;
 import hudson.model.listeners.ItemListener;
@@ -39,6 +40,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -145,12 +147,13 @@ public final class OldDataConverter extends ItemListener {
     public synchronized void onLoaded() {
         //Release the hounds!!!
         itemsLoaded = true;
-        for (String project : actionsToConvert.keySet()) {
-            List<FailureCauseMatrixBuildAction> actions = actionsToConvert.get(project);
+        for (Entry<String, List<FailureCauseMatrixBuildAction>> actionToConvert : actionsToConvert.entrySet()) {
+            List<FailureCauseMatrixBuildAction> actions = actionToConvert.getValue();
             logger.log(Level.FINE, "Scheduling conversion of {1} build actions for project {2}.",
-                    new Object[]{actions.size(), project});
+                    new Object[]{actions.size(), actionToConvert.getKey()});
             for (FailureCauseMatrixBuildAction action : actions) {
-                executor.schedule(new MatrixBuildActionWork(project, action), SCHEDULE_DELAY, TimeUnit.SECONDS);
+                executor.schedule(new MatrixBuildActionWork(actionToConvert.getKey(), action),
+                        SCHEDULE_DELAY, TimeUnit.SECONDS);
             }
         }
         actionsToConvert.clear();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:S2864 - "entrySet()" should be iterated when both the key and value are needed.
squid:S3400 - Methods should not return constants.
squid:S2178 - Short-circuit logic should be used in boolean contexts.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2864
https://dev.eclipse.org/sonar/rules/show/squid:S3400
https://dev.eclipse.org/sonar/rules/show/squid:S2178

Please let me know if you have any questions.

Faisal Hameed