### PR TITLE
General code quality fix-4

### DIFF
--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/db/Semaphore.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/db/Semaphore.java
@@ -30,13 +30,13 @@ package com.sonyericsson.jenkins.plugins.bfa.db;
  */
 public class Semaphore {
 
-    private java.util.concurrent.Semaphore semaphore;
+    private java.util.concurrent.Semaphore semaphoreLock;
 
     /**
      * Standard constructor.
      */
     public Semaphore() {
-        semaphore = new java.util.concurrent.Semaphore(0);
+        semaphoreLock = new java.util.concurrent.Semaphore(0);
     }
 
     /**
@@ -46,12 +46,12 @@ public class Semaphore {
      */
     public void acquire() throws InterruptedException {
         int take;
-        if (semaphore.availablePermits() < 1) {
+        if (semaphoreLock.availablePermits() < 1) {
             take = 1;
         } else {
-            take = semaphore.availablePermits();
+            take = semaphoreLock.availablePermits();
         }
-        semaphore.acquire(take);
+        semaphoreLock.acquire(take);
     }
 
     /**
@@ -59,6 +59,6 @@ public class Semaphore {
      * Releases a permit, returning it to the semaphore.
      */
     public void release() {
-        semaphore.release();
+        semaphoreLock.release();
     }
 }

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/graphs/ComputerGraphAction.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/graphs/ComputerGraphAction.java
@@ -117,7 +117,7 @@ public class ComputerGraphAction extends BfaGraphAction {
         if (computer == null) {
             return false;
         }
-        return (computer.getNode() instanceof Slave);
+        return computer.getNode() instanceof Slave;
     }
 
     @Override

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/indication/FoundIndication.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/indication/FoundIndication.java
@@ -50,6 +50,9 @@ public class FoundIndication {
      */
     protected static final String FILE_ENCODING = System.getProperty("file.encoding");
     private String matchingFile;
+    /**
+     * @deprecated, kept for backwards compatibility.
+     */
     @Deprecated
     private transient Integer matchingLine;
     private String pattern;

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/statistics/Statistics.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/statistics/Statistics.java
@@ -198,7 +198,7 @@ public class Statistics {
     }
 
         /**
-         * Deprecated, kept for backwards compatibility.
+         * @deprecated, kept for backwards compatibility.
          * @param projectName the project name.
          * @param buildNumber the build number.
          * @param startingTime the starting time.

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/db/SemaphoreTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/db/SemaphoreTest.java
@@ -43,7 +43,7 @@ public class SemaphoreTest {
     @Test(timeout = 20000)
     public void testAcquireAndRelease() throws Exception {
         Semaphore semaphore = new Semaphore();
-        java.util.concurrent.Semaphore innerSemaphore = Whitebox.getInternalState(semaphore, "semaphore");
+        java.util.concurrent.Semaphore innerSemaphore = Whitebox.getInternalState(semaphore, "semaphoreLock");
         assertEquals("The semaphore should have no available permits to start with", 0,
                 innerSemaphore.availablePermits());
         semaphore.release();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
squid:MissingDeprecatedCheck - Deprecated elements should have both the annotation and the Javadoc tag.
squid:S1700 - A field should not duplicate the name of its containing class.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
https://dev.eclipse.org/sonar/rules/show/squid:MissingDeprecatedCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1700

Please let me know if you have any questions.

Faisal Hameed