### PR TITLE
Set norefresh=true for this layout.

### DIFF
--- a/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/CauseManagement/index.groovy
+++ b/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/CauseManagement/index.groovy
@@ -32,7 +32,7 @@ def f = namespace(lib.FormTagLib)
 def l = namespace(lib.LayoutTagLib)
 def j = namespace(lib.JenkinsTagLib)
 
-l.layout(permission: PluginImpl.VIEW_PERMISSION) {
+l.layout(permission: PluginImpl.VIEW_PERMISSION, norefresh: true) {
   l.header(title: _("Failure Cause Management - Confirm Remove"))
 
   def management = CauseManagement.getInstance();


### PR DESCRIPTION
This page should not refresh automatically as form contents can be lost (when adding a new failure cause).