### PR TITLE
Pipeline support for Build Failure Analyzer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,12 @@
         </dependency>
         <!-- Test dependencies -->
         <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-aggregator</artifactId>
+            <version>1.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.11</version>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>com.sonyericsson.hudson.plugins.gerrit</groupId>
             <artifactId>gerrit-trigger</artifactId>
-            <version>2.7.0</version>
+            <version>2.15.0</version>
             <optional>true</optional>
             <exclusions>
                 <exclusion>

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/GerritMessageProviderExtension.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/GerritMessageProviderExtension.java
@@ -30,7 +30,7 @@ import com.sonyericsson.jenkins.plugins.bfa.model.FoundFailureCause;
 import com.sonyericsson.jenkins.plugins.bfa.model.indication.FoundIndication;
 
 import hudson.Extension;
-import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import hudson.model.Hudson;
 
 /**
@@ -43,7 +43,7 @@ import hudson.model.Hudson;
 public class GerritMessageProviderExtension extends GerritMessageProvider {
 
     @Override
-    public String getBuildCompletedMessage(AbstractBuild build) {
+    public String getBuildCompletedMessage(Run build) {
         if (PluginImpl.getInstance().isGerritTriggerEnabled()) {
             StringBuilder customMessage = new StringBuilder();
             if (build != null) {

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/IndicationAnnotatorFactory.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/IndicationAnnotatorFactory.java
@@ -28,7 +28,7 @@ import com.sonyericsson.jenkins.plugins.bfa.model.FoundFailureCause;
 import hudson.Extension;
 import hudson.console.ConsoleAnnotator;
 import hudson.console.ConsoleAnnotatorFactory;
-import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import org.kohsuke.stapler.Ancestor;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
@@ -50,12 +50,12 @@ public class IndicationAnnotatorFactory extends ConsoleAnnotatorFactory {
             //Accessed through some other means than http, so lets assume it is not a human.
             return null;
         }
-        Ancestor ancestor = currentRequest.findAncestor(AbstractBuild.class);
+        Ancestor ancestor = currentRequest.findAncestor(Run.class);
         if (ancestor == null) {
             return null;
         }
         Object object = ancestor.getObject();
-        AbstractBuild build = (AbstractBuild)object;
+        Run build = (Run)object;
         FailureCauseBuildAction action = build.getAction(FailureCauseBuildAction.class);
         if (action == null) {
             return null;

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/PluginImpl.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/PluginImpl.java
@@ -35,11 +35,11 @@ import hudson.ExtensionList;
 import hudson.Plugin;
 import hudson.PluginManager;
 import hudson.PluginWrapper;
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
 import hudson.model.Descriptor;
 import hudson.model.Hudson;
+import hudson.model.Job;
 import hudson.model.Result;
+import hudson.model.Run;
 import hudson.security.Permission;
 import hudson.security.PermissionGroup;
 import hudson.util.CopyOnWriteList;
@@ -476,10 +476,10 @@ public class PluginImpl extends Plugin {
      *
      * @param build the build
      * @return true if it should be scanned.
-     * @see {@link #shouldScan(AbstractProject)}
+     * @see {@link #shouldScan(Job)}
      */
-    public static boolean shouldScan(AbstractBuild build) {
-        return shouldScan(build.getProject());
+    public static boolean shouldScan(Run build) {
+        return shouldScan(build.getParent());
     }
 
     /**
@@ -489,7 +489,7 @@ public class PluginImpl extends Plugin {
      * @param project the project
      * @return true if it should be scanned.
      */
-    public static boolean shouldScan(AbstractProject project) {
+    public static boolean shouldScan(Job project) {
         if (getInstance().isGlobalEnabled()) {
             ScannerJobProperty property = (ScannerJobProperty)project.getProperty(ScannerJobProperty.class);
             if (property != null) {

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/TransientActionProvider.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/TransientActionProvider.java
@@ -25,9 +25,9 @@
 package com.sonyericsson.jenkins.plugins.bfa;
 
 import hudson.Extension;
-import hudson.model.AbstractProject;
 import hudson.model.Action;
-import hudson.model.TransientProjectActionFactory;
+import hudson.model.Job;
+import jenkins.model.TransientActionFactory;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -36,11 +36,16 @@ import java.util.Collections;
  * @author Robert Sandell &lt;robert.sandell@sonyericsson.com&gt;
  */
 @Extension
-public class TransientActionProvider extends TransientProjectActionFactory {
+public class TransientActionProvider extends TransientActionFactory<Job> {
 
 
     @Override
-    public Collection<? extends Action> createFor(AbstractProject target) {
+    public Class<Job> type() {
+        return Job.class;
+    }
+
+    @Override
+    public Collection<? extends Action> createFor(Job target) {
         if (PluginImpl.shouldScan(target)) {
             return Collections.singleton(new TransientCauseManagement(target));
         } else {

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/db/KnowledgeBase.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/db/KnowledgeBase.java
@@ -30,6 +30,8 @@ import com.sonyericsson.jenkins.plugins.bfa.model.FailureCause;
 import com.sonyericsson.jenkins.plugins.bfa.statistics.Statistics;
 import com.sonyericsson.jenkins.plugins.bfa.utils.ObjectCountPair;
 import hudson.ExtensionList;
+import hudson.Util;
+import hudson.model.AbstractBuild;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
 import hudson.model.Run;
@@ -351,8 +353,28 @@ public abstract class KnowledgeBase implements Describable<KnowledgeBase>, Seria
      * Removes the build failure cause of particular build.
      * @param build the build.
      * @throws Exception if something in the KnowledgeBase handling goes wrong.
+     * @deprecated use {@link #removeBuildfailurecause(hudson.model.Run)}
      */
-    public abstract void removeBuildfailurecause(Run build) throws Exception;
+    @Deprecated
+    public void removeBuildfailurecause(AbstractBuild build) throws Exception {
+        if (Util.isOverridden(KnowledgeBase.class, getClass(), "removeBuildfailurecause", Run.class)) {
+            removeBuildfailurecause((Run)build);
+        }
+    }
+
+    /**
+     * Removes the build failure cause of particular build.
+     * @param build the build.
+     * @throws Exception if something in the KnowledgeBase handling goes wrong.
+     */
+    public void removeBuildfailurecause(Run build) throws Exception {
+        if (Util.isOverridden(KnowledgeBase.class, getClass(), "removeBuildfailurecause", AbstractBuild.class)) {
+            removeBuildfailurecause((AbstractBuild)build);
+        }
+    }
+
+
+
     /**
      * Descriptor for {@link KnowledgeBase}s.
      */

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/db/KnowledgeBase.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/db/KnowledgeBase.java
@@ -30,9 +30,9 @@ import com.sonyericsson.jenkins.plugins.bfa.model.FailureCause;
 import com.sonyericsson.jenkins.plugins.bfa.statistics.Statistics;
 import com.sonyericsson.jenkins.plugins.bfa.utils.ObjectCountPair;
 import hudson.ExtensionList;
-import hudson.model.AbstractBuild;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
+import hudson.model.Run;
 import jenkins.model.Jenkins;
 import org.jfree.data.time.TimePeriod;
 
@@ -349,10 +349,10 @@ public abstract class KnowledgeBase implements Describable<KnowledgeBase>, Seria
 
     /**
      * Removes the build failure cause of particular build.
-     * @param build the AbstractBuild.
+     * @param build the build.
      * @throws Exception if something in the KnowledgeBase handling goes wrong.
      */
-    public abstract void removeBuildfailurecause(AbstractBuild build) throws Exception;
+    public abstract void removeBuildfailurecause(Run build) throws Exception;
     /**
      * Descriptor for {@link KnowledgeBase}s.
      */

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/db/LocalFileKnowledgeBase.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/db/LocalFileKnowledgeBase.java
@@ -41,8 +41,8 @@ import com.sonyericsson.jenkins.plugins.bfa.PluginImpl;
 import com.sonyericsson.jenkins.plugins.bfa.model.FailureCause;
 import com.sonyericsson.jenkins.plugins.bfa.statistics.Statistics;
 import hudson.Extension;
-import hudson.model.AbstractBuild;
 import hudson.model.Descriptor;
+import hudson.model.Run;
 import hudson.util.CopyOnWriteList;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -229,7 +229,7 @@ public class LocalFileKnowledgeBase extends KnowledgeBase {
     }
 
     @Override
-    public void removeBuildfailurecause(AbstractBuild build) throws Exception {
+    public void removeBuildfailurecause(Run build) throws Exception {
         //Not implemented
     }
 

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/db/MongoDBKnowledgeBase.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/db/MongoDBKnowledgeBase.java
@@ -43,8 +43,8 @@ import com.sonyericsson.jenkins.plugins.bfa.utils.BfaUtils;
 import com.sonyericsson.jenkins.plugins.bfa.utils.ObjectCountPair;
 import hudson.Extension;
 import hudson.Util;
-import hudson.model.AbstractBuild;
 import hudson.model.Descriptor;
+import hudson.model.Run;
 import hudson.util.FormValidation;
 import hudson.util.Secret;
 import jenkins.model.Jenkins;
@@ -988,9 +988,9 @@ public class MongoDBKnowledgeBase extends KnowledgeBase {
     }
 
     @Override
-    public void removeBuildfailurecause(AbstractBuild build) throws Exception {
+    public void removeBuildfailurecause(Run build) throws Exception {
         BasicDBObject searchObj = new BasicDBObject();
-        searchObj.put("projectName", build.getProject().getFullName());
+        searchObj.put("projectName", build.getParent().getFullName());
         searchObj.put("buildNumber", build.getNumber());
         searchObj.put("master", BfaUtils.getMasterName());
         com.mongodb.DBCursor dbcursor = getStatisticsCollection().find(searchObj);

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/graphs/BFAGraph.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/graphs/BFAGraph.java
@@ -28,7 +28,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import hudson.model.AbstractProject;
+import hudson.model.Job;
 import hudson.model.Run;
 import hudson.util.Graph;
 import hudson.util.RunList;
@@ -44,7 +44,7 @@ public abstract class BFAGraph extends Graph {
     /**
      * The project that this graph is plotting values for. Is null for non-project graphs.
      */
-    protected AbstractProject project;
+    protected Job project;
     /**
      * The data filter used for this graph.
      */
@@ -99,7 +99,7 @@ public abstract class BFAGraph extends Graph {
      *            The title of the graph
      */
     protected BFAGraph(long timestamp, int defaultW, int defaultH,
-            AbstractProject project, GraphFilterBuilder filter,
+            Job project, GraphFilterBuilder filter,
             String graphTitle) {
         super(timestamp, defaultW, defaultH);
         this.project = project;
@@ -112,7 +112,7 @@ public abstract class BFAGraph extends Graph {
      * @param project the project to list build numbers for
      * @return list of build numbers, empty if project is null
      */
-    public static List<Integer> getBuildNumbers(AbstractProject project) {
+    public static List<Integer> getBuildNumbers(Job project) {
         List<Integer> buildNumbers = new ArrayList<Integer>();
         if (project != null) {
             RunList runList = project.getBuilds();

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/graphs/BarChart.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/graphs/BarChart.java
@@ -23,10 +23,9 @@
  */
 package com.sonyericsson.jenkins.plugins.bfa.graphs;
 
-import hudson.model.AbstractProject;
-
 import java.util.List;
 
+import hudson.model.Job;
 import org.jfree.chart.ChartFactory;
 import org.jfree.chart.JFreeChart;
 import org.jfree.chart.axis.NumberAxis;
@@ -65,7 +64,7 @@ public class BarChart extends BFAGraph {
      * @param byCategories True to display categories, or false to display failure causes
      */
     public BarChart(long timestamp, int defaultW, int defaultH,
-            AbstractProject project, GraphFilterBuilder filter,
+            Job project, GraphFilterBuilder filter,
             String graphTitle, boolean byCategories) {
         super(timestamp, defaultW, defaultH, project, filter, graphTitle);
         this.byCategories = byCategories;

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/graphs/BuildNbrStackedBarChart.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/graphs/BuildNbrStackedBarChart.java
@@ -27,13 +27,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import hudson.model.Job;
 import org.jfree.data.category.DefaultCategoryDataset;
 
 import com.sonyericsson.jenkins.plugins.bfa.PluginImpl;
 import com.sonyericsson.jenkins.plugins.bfa.db.KnowledgeBase;
 import com.sonyericsson.jenkins.plugins.bfa.model.FailureCause;
-
-import hudson.model.AbstractProject;
 
 /**
  * Stacked bar chart displaying the number of different failure causes for every build number.
@@ -60,7 +59,7 @@ public class BuildNbrStackedBarChart extends StackedBarChart {
      * @param graphTitle The title of the graph
      */
     protected BuildNbrStackedBarChart(long timestamp, int defaultW,
-            int defaultH, AbstractProject project, GraphFilterBuilder filter,
+            int defaultH, Job project, GraphFilterBuilder filter,
             int nbrOfBuildsToShow, String graphTitle) {
         super(timestamp, defaultW, defaultH, project, filter, graphTitle);
         this.nbrOfBuildsToShow = nbrOfBuildsToShow;

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/graphs/PieChart.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/graphs/PieChart.java
@@ -23,10 +23,9 @@
  */
 package com.sonyericsson.jenkins.plugins.bfa.graphs;
 
-import hudson.model.AbstractProject;
-
 import java.util.List;
 
+import hudson.model.Job;
 import org.jfree.chart.ChartFactory;
 import org.jfree.chart.JFreeChart;
 import org.jfree.data.general.DefaultPieDataset;
@@ -57,7 +56,7 @@ public class PieChart extends BFAGraph {
      * @param byCategories True to display categories, or false for failure causes
      */
     public PieChart(long timestamp, int defaultW, int defaultH,
-            AbstractProject project, GraphFilterBuilder filter,
+            Job project, GraphFilterBuilder filter,
             String graphTitle, boolean byCategories) {
         super(timestamp, defaultW, defaultH, project, filter, graphTitle);
         this.byCategories = byCategories;

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/graphs/ProjectGraphAction.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/graphs/ProjectGraphAction.java
@@ -23,8 +23,8 @@
  */
 package com.sonyericsson.jenkins.plugins.bfa.graphs;
 
+import hudson.model.Job;
 import hudson.model.ModelObject;
-import hudson.model.AbstractProject;
 import hudson.util.Graph;
 
 import java.util.Date;
@@ -51,13 +51,13 @@ public class ProjectGraphAction extends BfaGraphAction {
     private static final String GRAPH_TITLE_CATEGORIES = "Failures grouped by categories for this project";
     private static final String BUILD_NBR_TITLE = "Failure causes per build for this project";
 
-    private AbstractProject project;
+    private Job project;
 
     /**
      * Standard constructor.
      * @param project the parent project of this action
      */
-    public ProjectGraphAction(AbstractProject project) {
+    public ProjectGraphAction(Job project) {
         this.project = project;
     }
 
@@ -191,7 +191,7 @@ public class ProjectGraphAction extends BfaGraphAction {
      * Invalidate the cache for the build number graph for the specified project.
      * @param project The project whose build number graph to invalidate
      */
-    public static void invalidateBuildNbrGraphCache(AbstractProject project) {
+    public static void invalidateBuildNbrGraphCache(Job project) {
         GraphCache.getInstance().invalidate(ProjectGraphAction.getCacheIdForBuildNbrs(project.getFullName()));
     }
 
@@ -199,7 +199,7 @@ public class ProjectGraphAction extends BfaGraphAction {
      * Invalidate all graph caches for the specified project.
      * @param project The project whose graphs to invalidate
      */
-    public static void invalidateProjectGraphCache(AbstractProject project) {
+    public static void invalidateProjectGraphCache(Job project) {
         Pattern projectPattern = Pattern.compile("^.*" + ID_SEPARATOR
                 + project.getFullName() + ID_SEPARATOR + ".*$");
         GraphCache.getInstance().invalidateMatching(projectPattern);

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/graphs/StackedBarChart.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/graphs/StackedBarChart.java
@@ -23,8 +23,7 @@
  */
 package com.sonyericsson.jenkins.plugins.bfa.graphs;
 
-import hudson.model.AbstractProject;
-
+import hudson.model.Job;
 import org.jfree.chart.ChartFactory;
 import org.jfree.chart.JFreeChart;
 import org.jfree.chart.axis.CategoryAxis;
@@ -61,7 +60,7 @@ public abstract class StackedBarChart extends BFAGraph {
      * @param filter the filter used when fetching data for this graph
      * @param graphTitle The title of the graph
      */
-    public StackedBarChart(long timestamp, int defaultW, int defaultH, AbstractProject project,
+    public StackedBarChart(long timestamp, int defaultW, int defaultH, Job project,
             GraphFilterBuilder filter, String graphTitle) {
         super(timestamp, defaultW, defaultH, project, filter, graphTitle);
     }

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/graphs/TimeSeriesChart.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/graphs/TimeSeriesChart.java
@@ -23,8 +23,6 @@
  */
 package com.sonyericsson.jenkins.plugins.bfa.graphs;
 
-import hudson.model.AbstractProject;
-
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collection;
@@ -38,6 +36,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import hudson.model.Job;
 import org.jfree.chart.JFreeChart;
 import org.jfree.chart.axis.DateAxis;
 import org.jfree.chart.axis.NumberAxis;
@@ -89,7 +88,7 @@ public class TimeSeriesChart extends BFAGraph {
      * @param graphTitle The title of the graph
      */
     public TimeSeriesChart(long timestamp, int defaultW, int defaultH,
-            AbstractProject project, GraphFilterBuilder filter,
+            Job project, GraphFilterBuilder filter,
             int intervalSize, boolean groupByCategories, String graphTitle) {
         super(timestamp, defaultW, defaultH, project, filter, graphTitle);
         this.intervalSize = intervalSize;

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/graphs/TimeSeriesUnkownFailuresChart.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/graphs/TimeSeriesUnkownFailuresChart.java
@@ -23,12 +23,11 @@
  */
 package com.sonyericsson.jenkins.plugins.bfa.graphs;
 
-import hudson.model.AbstractProject;
-
 import java.util.Calendar;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import hudson.model.Job;
 import org.jfree.chart.JFreeChart;
 import org.jfree.chart.axis.DateAxis;
 import org.jfree.chart.axis.NumberAxis;
@@ -64,7 +63,7 @@ public class TimeSeriesUnkownFailuresChart extends TimeSeriesChart {
      * @param intervalSize the interval sizes in which the data is grouped
      * @param graphTitle The title of the graph
      */
-    public TimeSeriesUnkownFailuresChart(long timestamp, int defaultW, int defaultH, AbstractProject project,
+    public TimeSeriesUnkownFailuresChart(long timestamp, int defaultW, int defaultH, Job project,
             GraphFilterBuilder filter, int intervalSize, String graphTitle) {
         super(timestamp, defaultW, defaultH, project, filter, intervalSize, false, graphTitle);
     }

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/BuildLogFailureReader.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/BuildLogFailureReader.java
@@ -26,7 +26,7 @@ package com.sonyericsson.jenkins.plugins.bfa.model;
 
 import com.sonyericsson.jenkins.plugins.bfa.model.indication.BuildLogIndication;
 import com.sonyericsson.jenkins.plugins.bfa.model.indication.FoundIndication;
-import hudson.model.AbstractBuild;
+import hudson.model.Run;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -60,7 +60,7 @@ public class BuildLogFailureReader extends FailureReader {
      * is found in the log of the given build; return null otherwise.
      * @throws IOException if so.
      */
-    public FoundIndication scan(AbstractBuild build) throws IOException {
+    public FoundIndication scan(Run build) throws IOException {
         String currentfile = build.getLogFile().getName();
         BufferedReader reader = null;
         try {
@@ -87,7 +87,7 @@ public class BuildLogFailureReader extends FailureReader {
      * @return a FoundIndication if something was found, null if not.
      */
     @Override
-    public FoundIndication scan(AbstractBuild build, PrintStream buildLog) {
+    public FoundIndication scan(Run build, PrintStream buildLog) {
         FoundIndication foundIndication = null;
         String currentFile = build.getLogFile().getName();
         BufferedReader reader = null;

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCause.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCause.java
@@ -32,11 +32,11 @@ import hudson.Util;
 import hudson.model.Action;
 import hudson.model.AutoCompletionCandidates;
 import hudson.model.Describable;
+import hudson.model.Descriptor;
 import hudson.model.Failure;
 import hudson.model.Hudson;
+import hudson.model.Job;
 import hudson.model.User;
-import hudson.model.Descriptor;
-import hudson.model.AbstractProject;
 import hudson.util.FormValidation;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
@@ -647,7 +647,7 @@ public class FailureCause implements Serializable, Action, Describable<FailureCa
         public void setLastFailedBuildUrl() {
             StaplerRequest staplerRequest = Stapler.getCurrentRequest();
             if (staplerRequest != null) {
-                AbstractProject project = staplerRequest.findAncestorObject(AbstractProject.class);
+                Job project = staplerRequest.findAncestorObject(Job.class);
                 if (project != null && project.getLastFailedBuild() != null) {
                     staplerRequest.getSession(true).setAttribute(LAST_FAILED_BUILD_URL_SESSION_ATTRIBUTE_NAME,
                             Hudson.getInstance().getRootUrl() + project.getLastFailedBuild().getUrl());

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCauseBuildAction.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCauseBuildAction.java
@@ -29,9 +29,9 @@ import com.sonyericsson.jenkins.plugins.bfa.Messages;
 import com.sonyericsson.jenkins.plugins.bfa.PluginImpl;
 import com.sonyericsson.jenkins.plugins.bfa.model.dbf.DownstreamBuildFinder;
 import hudson.matrix.MatrixRun;
-import hudson.model.AbstractBuild;
 import hudson.model.BuildBadgeAction;
 import hudson.model.Hudson;
+import hudson.model.Run;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.export.Exported;
@@ -60,7 +60,7 @@ public class FailureCauseBuildAction implements BuildBadgeAction {
     public static final String URL_NAME = "bfa";
     private static final Logger logger = Logger.getLogger(FailureCauseBuildAction.class.getName());
 
-    private AbstractBuild build;
+    private Run build;
 
     /**
      * Standard constructor.
@@ -186,7 +186,7 @@ public class FailureCauseBuildAction implements BuildBadgeAction {
      *
      * @param build - the build corresponding to this action
      */
-    public void setBuild(AbstractBuild build) {
+    public void setBuild(Run build) {
         this.build = build;
     }
 
@@ -195,7 +195,7 @@ public class FailureCauseBuildAction implements BuildBadgeAction {
      *
      * @return the build corresponding to this action
      */
-    public AbstractBuild getBuild() {
+    public Run getBuild() {
         return build;
     }
 
@@ -242,11 +242,11 @@ public class FailureCauseBuildAction implements BuildBadgeAction {
             // Add causes from this build
             displayData.setFoundFailureCauses(
                     buildAction.getFoundFailureCauses());
-            for (AbstractBuild abstractBuild
+            for (Run run
                     : getDownstreamBuilds(buildAction.getBuild())) {
 
                 checkSubFailureCauseBuildAction(
-                        abstractBuild, displayData, depth);
+                        run, displayData, depth);
             }
         }
         return displayData;
@@ -256,22 +256,22 @@ public class FailureCauseBuildAction implements BuildBadgeAction {
      * Check if the build has the action FailureCauseBuildAction. If so, add
      * information to the display data.
      *
-     * @param abstractBuild the build under investigation
+     * @param run the build under investigation
      * @param displayData object holding display information
      * @param depth recursive depth
      */
     private static void checkSubFailureCauseBuildAction(
-            final AbstractBuild abstractBuild,
+            final Run run,
             final FailureCauseDisplayData displayData,
             final int depth) {
         FailureCauseBuildAction subAction =
-                abstractBuild.getAction(FailureCauseBuildAction.class);
+                run.getAction(FailureCauseBuildAction.class);
         if (subAction != null) {
             setSubDisplayData(subAction, displayData, depth);
         } else {
             // Nested matrix build
             FailureCauseMatrixBuildAction subMatrixAction =
-                    abstractBuild.getAction(
+                    run.getAction(
                             FailureCauseMatrixBuildAction.class);
             if (subMatrixAction != null) {
                 for (MatrixRun matrixRun
@@ -281,7 +281,7 @@ public class FailureCauseBuildAction implements BuildBadgeAction {
                     if (action != null) {
                         FailureCauseDisplayData subDisplayData =
                                 setSubDisplayData(action, displayData, depth);
-                        adjustProjectDisplayName(abstractBuild, subDisplayData);
+                        adjustProjectDisplayName(run, subDisplayData);
                     }
                 }
             }
@@ -315,15 +315,15 @@ public class FailureCauseBuildAction implements BuildBadgeAction {
      * When nested there is one link to the project and one to the build. The
      * build nbr is removed from the name.
      *
-     * @param abstractBuild the build generating the build failure
+     * @param run the build generating the build failure
      * @param subDisplayData the data object to update
      */
     private static void adjustProjectDisplayName(
-            final AbstractBuild abstractBuild,
+            final Run run,
             final FailureCauseDisplayData subDisplayData) {
         if (subDisplayData != null) {
             subDisplayData.getLinks().setProjectDisplayName(
-                    abstractBuild.getParent().getFullName() + " » "
+                    run.getParent().getFullName() + " » "
                     + subDisplayData.getLinks().getProjectDisplayName());
         }
     }
@@ -335,16 +335,16 @@ public class FailureCauseBuildAction implements BuildBadgeAction {
      * @param build collect downstream builds from this
      * @return a set of downstream builds
      */
-    private static Set<AbstractBuild<?, ?>> getDownstreamBuilds(
-            final AbstractBuild build) {
+    private static Set<Run<?, ?>> getDownstreamBuilds(
+            final Run build) {
 
-        Set<AbstractBuild<?, ?>> foundDbf = new TreeSet<AbstractBuild<?, ?>>();
+        Set<Run<?, ?>> foundDbf = new TreeSet<Run<?, ?>>();
 
         for (DownstreamBuildFinder dbf : DownstreamBuildFinder.getAll()) {
 
-            List<AbstractBuild<?, ?>> downstreamBuilds = dbf.getDownstreamBuilds(build);
+            List<Run<?, ?>> downstreamBuilds = dbf.getDownstreamBuilds(build);
 
-            for (AbstractBuild<?, ?> downstreamBuild : downstreamBuilds) {
+            for (Run<?, ?> downstreamBuild : downstreamBuilds) {
                 if (downstreamBuild != null) {
                     foundDbf.add(downstreamBuild);
                 } else {

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCauseDisplayData.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCauseDisplayData.java
@@ -23,7 +23,7 @@ package com.sonyericsson.jenkins.plugins.bfa.model;
  * THE SOFTWARE.
  */
 
-import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import org.kohsuke.stapler.export.ExportedBean;
 
 import java.util.LinkedList;
@@ -54,7 +54,7 @@ public class FailureCauseDisplayData {
      *
      * @param build corresponding build
      */
-    public FailureCauseDisplayData(final AbstractBuild build) {
+    public FailureCauseDisplayData(final Run build) {
         links = new Links(build);
     }
 
@@ -123,10 +123,10 @@ public class FailureCauseDisplayData {
          *
          * @param build - the build to extract link info from
          */
-        private Links(final AbstractBuild build) {
-            this.projectUrl = build.getProject().getUrl();
+        private Links(final Run build) {
+            this.projectUrl = build.getParent().getUrl();
             this.buildUrl = build.getUrl();
-            this.projectDisplayName = build.getProject().getDisplayName();
+            this.projectDisplayName = build.getParent().getDisplayName();
             this.buildDisplayName = build.getDisplayName();
         }
 

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCauseProjectAction.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCauseProjectAction.java
@@ -23,12 +23,12 @@
  */
 package com.sonyericsson.jenkins.plugins.bfa.model;
 
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
 import hudson.model.InvisibleAction;
 
 import javax.annotation.Nonnull;
 
+import hudson.model.Job;
+import hudson.model.Run;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -40,12 +40,12 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 @Restricted(NoExternalUse.class)
 public class FailureCauseProjectAction extends InvisibleAction {
 
-    private final AbstractProject<?, ?> job;
+    private final Job<?, ?> job;
 
     /**
      * @param job A project to report.
      */
-    public FailureCauseProjectAction(@Nonnull AbstractProject<?, ?> job) {
+    public FailureCauseProjectAction(@Nonnull Job<?, ?> job) {
         this.job = job;
     }
 
@@ -53,7 +53,7 @@ public class FailureCauseProjectAction extends InvisibleAction {
      * @return Build action to report.
      */
     public FailureCauseBuildAction getAction() {
-        AbstractBuild<?, ?> build = job.getLastCompletedBuild();
+        Run<?, ?> build = job.getLastCompletedBuild();
         if (build == null) {
             return null;
         }

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureReader.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureReader.java
@@ -37,7 +37,7 @@ import com.google.common.base.Joiner;
 import com.sonyericsson.jenkins.plugins.bfa.model.indication.FoundIndication;
 import com.sonyericsson.jenkins.plugins.bfa.model.indication.Indication;
 import hudson.console.ConsoleNote;
-import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import org.codehaus.jackson.annotate.JsonIgnoreType;
 
 /**
@@ -74,7 +74,7 @@ public abstract class FailureReader {
      * is found in the log of the given build; return null otherwise.
      * @throws IOException if so.
      */
-    public abstract FoundIndication scan(AbstractBuild build) throws IOException;
+    public abstract FoundIndication scan(Run build) throws IOException;
 
     /**
      * Scans for indications of a failure cause.
@@ -82,7 +82,7 @@ public abstract class FailureReader {
      * @param buildLog the log of the build.
      * @return a FoundIndication if something was found, null if not.
      */
-    public abstract FoundIndication scan(AbstractBuild build, PrintStream buildLog);
+    public abstract FoundIndication scan(Run build, PrintStream buildLog);
 
     /**
      * Scans one file for the required pattern.
@@ -92,7 +92,7 @@ public abstract class FailureReader {
      * @return a FoundIndication if we find the pattern, null if not.
      * @throws IOException if problems occur in the reader handling.
      */
-    protected FoundIndication scanOneFile(AbstractBuild build, BufferedReader reader, String currentFile)
+    protected FoundIndication scanOneFile(Run build, BufferedReader reader, String currentFile)
             throws IOException {
         TimerThread timerThread = new TimerThread(Thread.currentThread(), TIMEOUT_LINE);
         FoundIndication foundIndication = null;
@@ -152,7 +152,7 @@ public abstract class FailureReader {
      * @return a FoundIndication if we find the pattern, null if not.
      * @throws IOException if problems occur in the reader handling.
      */
-    protected FoundIndication scanMultiLineOneFile(AbstractBuild build, BufferedReader reader, String currentFile)
+    protected FoundIndication scanMultiLineOneFile(Run build, BufferedReader reader, String currentFile)
             throws IOException {
         TimerThread timerThread = new TimerThread(Thread.currentThread(), TIMEOUT_LINE);
         FoundIndication foundIndication = null;

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureReader.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureReader.java
@@ -36,7 +36,9 @@ import java.util.regex.Pattern;
 import com.google.common.base.Joiner;
 import com.sonyericsson.jenkins.plugins.bfa.model.indication.FoundIndication;
 import com.sonyericsson.jenkins.plugins.bfa.model.indication.Indication;
+import hudson.Util;
 import hudson.console.ConsoleNote;
+import hudson.model.AbstractBuild;
 import hudson.model.Run;
 import org.codehaus.jackson.annotate.JsonIgnoreType;
 
@@ -73,8 +75,45 @@ public abstract class FailureReader {
      * @return a FoundIndication if the pattern given by this FailureReader
      * is found in the log of the given build; return null otherwise.
      * @throws IOException if so.
+     * @deprecated use {@link #scan(hudson.model.Run)}.
      */
-    public abstract FoundIndication scan(Run build) throws IOException;
+    @Deprecated
+    public FoundIndication scan(AbstractBuild build) throws IOException {
+        if (Util.isOverridden(FailureReader.class, getClass(), "scan", Run.class)) {
+            return scan((Run) build);
+        }
+        return null;
+    }
+
+    /**
+     * Scans a build log.
+     *
+     * @param build - the build whose log should be scanned.
+     * @return a FoundIndication if the pattern given by this FailureReader
+     * is found in the log of the given build; return null otherwise.
+     * @throws IOException if so.
+     */
+    public FoundIndication scan(Run build) throws IOException {
+        if (Util.isOverridden(FailureReader.class, getClass(), "scan", AbstractBuild.class)) {
+            return scan((AbstractBuild) build);
+        }
+        return null;
+    }
+
+    /**
+     * Scans for indications of a failure cause.
+     * @param build the build to scan for indications.
+     * @param buildLog the log of the build.
+     * @return a FoundIndication if something was found, null if not.
+     * @deprecated Use {@link #scan(hudson.model.Run, java.io.PrintStream)}.
+     */
+    @Deprecated
+    public FoundIndication scan(AbstractBuild build, PrintStream buildLog) {
+        if (Util.isOverridden(FailureReader.class, getClass(), "scan", Run.class, PrintStream.class)) {
+            return scan((Run) build, buildLog);
+        }
+        return null;
+    }
 
     /**
      * Scans for indications of a failure cause.
@@ -82,7 +121,12 @@ public abstract class FailureReader {
      * @param buildLog the log of the build.
      * @return a FoundIndication if something was found, null if not.
      */
-    public abstract FoundIndication scan(Run build, PrintStream buildLog);
+    public FoundIndication scan(Run build, PrintStream buildLog) {
+        if (Util.isOverridden(FailureReader.class, getClass(), "scan", AbstractBuild.class, PrintStream.class)) {
+            return scan((AbstractBuild) build, buildLog);
+        }
+        return null;
+    }
 
     /**
      * Scans one file for the required pattern.

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/MultilineBuildLogFailureReader.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/MultilineBuildLogFailureReader.java
@@ -32,7 +32,7 @@ import java.util.logging.Logger;
 
 import com.sonyericsson.jenkins.plugins.bfa.model.indication.FoundIndication;
 import com.sonyericsson.jenkins.plugins.bfa.model.indication.MultilineBuildLogIndication;
-import hudson.model.AbstractBuild;
+import hudson.model.Run;
 
 
 /**
@@ -60,7 +60,7 @@ public class MultilineBuildLogFailureReader extends FailureReader {
      * is found in the log of the given build; return null otherwise.
      * @throws java.io.IOException if so.
      */
-    public FoundIndication scan(AbstractBuild build) throws IOException {
+    public FoundIndication scan(Run build) throws IOException {
         String currentfile = build.getLogFile().getName();
         BufferedReader reader = null;
         try {
@@ -87,7 +87,7 @@ public class MultilineBuildLogFailureReader extends FailureReader {
      * @return a FoundIndication if something was found, null if not.
      */
     @Override
-    public FoundIndication scan(AbstractBuild build, PrintStream buildLog) {
+    public FoundIndication scan(Run build, PrintStream buildLog) {
         FoundIndication foundIndication = null;
         String currentFile = build.getLogFile().getName();
         BufferedReader reader = null;

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/ScannerJobProperty.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/ScannerJobProperty.java
@@ -31,9 +31,9 @@ import hudson.Launcher;
 import hudson.matrix.MatrixAggregatable;
 import hudson.matrix.MatrixAggregator;
 import hudson.matrix.MatrixBuild;
-import hudson.model.AbstractProject;
 import hudson.model.Action;
 import hudson.model.BuildListener;
+import hudson.model.Job;
 import hudson.model.JobProperty;
 import hudson.model.JobPropertyDescriptor;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -48,7 +48,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  *
  * @author Robert Sandell &lt;robert.sandell@sonymobile.com&gt;
  */
-public class ScannerJobProperty extends JobProperty<AbstractProject<?, ?>> implements MatrixAggregatable, Serializable {
+public class ScannerJobProperty extends JobProperty<Job<?, ?>> implements MatrixAggregatable, Serializable {
 
     private boolean doNotScan;
 
@@ -79,7 +79,7 @@ public class ScannerJobProperty extends JobProperty<AbstractProject<?, ?>> imple
 
     @Override
     @Restricted(NoExternalUse.class)
-    public Action getJobAction(AbstractProject<?, ?> job) {
+    public Action getJobAction(Job<?, ?> job) {
         return new FailureCauseProjectAction(job);
     }
 

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/ScannerOffJobProperty.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/ScannerOffJobProperty.java
@@ -24,7 +24,7 @@
 
 package com.sonyericsson.jenkins.plugins.bfa.model;
 
-import hudson.model.AbstractProject;
+import hudson.model.Job;
 import hudson.model.JobProperty;
 
 import java.io.Serializable;
@@ -36,7 +36,7 @@ import java.io.Serializable;
  * @deprecated {@link ScannerJobProperty} is used instead, but this is kept to be able to de-serialize old jobs.
  */
 @Deprecated
-public class ScannerOffJobProperty extends JobProperty<AbstractProject<?, ?>> implements Serializable {
+public class ScannerOffJobProperty extends JobProperty<Job<?, ?>> implements Serializable {
     private boolean doNotScan;
 
     /**

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/ScannerOffJobProperty.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/ScannerOffJobProperty.java
@@ -24,7 +24,7 @@
 
 package com.sonyericsson.jenkins.plugins.bfa.model;
 
-import hudson.model.Job;
+import hudson.model.AbstractProject;
 import hudson.model.JobProperty;
 
 import java.io.Serializable;
@@ -36,7 +36,7 @@ import java.io.Serializable;
  * @deprecated {@link ScannerJobProperty} is used instead, but this is kept to be able to de-serialize old jobs.
  */
 @Deprecated
-public class ScannerOffJobProperty extends JobProperty<Job<?, ?>> implements Serializable {
+public class ScannerOffJobProperty extends JobProperty<AbstractProject<?, ?>> implements Serializable {
     private boolean doNotScan;
 
     /**

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/dbf/BuildFlowDBF.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/dbf/BuildFlowDBF.java
@@ -25,7 +25,7 @@
 package com.sonyericsson.jenkins.plugins.bfa.model.dbf;
 
 import hudson.Extension;
-import hudson.model.AbstractBuild;
+import hudson.model.Run;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -43,8 +43,8 @@ import java.util.concurrent.ExecutionException;
 public class BuildFlowDBF extends DownstreamBuildFinder {
 
     @Override
-    public List<AbstractBuild<?, ?>> getDownstreamBuilds(
-            final AbstractBuild build) {
+    public List<Run<?, ?>> getDownstreamBuilds(
+            final Run build) {
 
         if (build == null) {
             return EMPTY;
@@ -57,12 +57,12 @@ public class BuildFlowDBF extends DownstreamBuildFinder {
         Set<com.cloudbees.plugins.flow.JobInvocation> vertexSet =
                 ((com.cloudbees.plugins.flow.FlowRun)build).getJobsGraph().vertexSet();
 
-        List<AbstractBuild<?, ?>> result = new ArrayList<AbstractBuild<?, ?>>(vertexSet.size());
+        List<Run<?, ?>> result = new ArrayList<Run<?, ?>>(vertexSet.size());
 
         //CS IGNORE EmptyBlock FOR NEXT 10 LINES. REASON: irrelevant exceptions.
         for (com.cloudbees.plugins.flow.JobInvocation invocation : vertexSet) {
             try {
-                result.add((AbstractBuild<?, ?>)invocation.getBuild());
+                result.add((Run<?, ?>)invocation.getBuild());
             } catch (ExecutionException e) {
                 // skip
             } catch (InterruptedException e) {

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/dbf/CoreDBF.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/dbf/CoreDBF.java
@@ -26,8 +26,9 @@ package com.sonyericsson.jenkins.plugins.bfa.model.dbf;
 
 import hudson.Extension;
 import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
 import hudson.model.Fingerprint;
+import hudson.model.Job;
+import hudson.model.Run;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -50,21 +51,22 @@ public class CoreDBF extends DownstreamBuildFinder {
      * @return alist with downstream builds
      */
     @Override
-    public List<AbstractBuild<?, ?>> getDownstreamBuilds(
-            final AbstractBuild build) {
+    public List<Run<?, ?>> getDownstreamBuilds(
+            final Run build) {
 
-        LinkedList<AbstractBuild<?, ?>> foundBuilds =
-                new LinkedList<AbstractBuild<?, ?>>();
+        Map<Job, Fingerprint.RangeSet> buildMap = null;
+        if (build instanceof AbstractBuild) {
+            buildMap = ((AbstractBuild)build).getDownstreamBuilds();
+        }
+        LinkedList<Run<?, ?>> foundBuilds =
+                new LinkedList<Run<?, ?>>();
 
-        Map<AbstractProject, Fingerprint.RangeSet> buildMap =
-                build.getDownstreamBuilds();
 
-        if (!buildMap.isEmpty()) {
-            for (Map.Entry<AbstractProject, Fingerprint.RangeSet> entry
+        if (buildMap != null && !buildMap.isEmpty()) {
+            for (Map.Entry<Job, Fingerprint.RangeSet> entry
                     : buildMap.entrySet()) {
-
                 for (Integer buildId : entry.getValue().listNumbers()) {
-                    foundBuilds.add((AbstractBuild<?, ?>)
+                    foundBuilds.add((Run<?, ?>)
                             entry.getKey().getBuildByNumber(buildId));
                 }
             }

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/dbf/DownstreamBuildFinder.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/dbf/DownstreamBuildFinder.java
@@ -26,6 +26,8 @@ package com.sonyericsson.jenkins.plugins.bfa.model.dbf;
 
 import hudson.ExtensionList;
 import hudson.ExtensionPoint;
+import hudson.Util;
+import hudson.model.AbstractBuild;
 import hudson.model.Hudson;
 import hudson.model.Run;
 
@@ -57,9 +59,28 @@ public abstract class DownstreamBuildFinder implements ExtensionPoint {
      *
      * @param build get the downstream build(s) relative this build
      * @return a list with downstream builds
+     * @deprecated use {@link #getDownstreamBuilds(hudson.model.Run)}
      */
-    public abstract List<Run<?, ?>> getDownstreamBuilds(
-            final Run build);
+    @Deprecated
+    public List<Run<?, ?>> getDownstreamBuilds(final AbstractBuild build) {
+        if (Util.isOverridden(DownstreamBuildFinder.class, getClass(), "getDownstreamBuilds", Run.class)) {
+            return getDownstreamBuilds((Run) build);
+        }
+        return null;
+    }
+
+    /**
+     * Return a list of all downstream builds originating from provided build.
+     *
+     * @param build get the downstream build(s) relative this build
+     * @return a list with downstream builds
+     */
+    public List<Run<?, ?>> getDownstreamBuilds(final Run build) {
+        if (Util.isOverridden(DownstreamBuildFinder.class, getClass(), "getDownstreamBuilds", AbstractBuild.class)) {
+            return getDownstreamBuilds((AbstractBuild)build);
+        }
+        return null;
+    }
 
     /**
      * Return a list of all registered DownstreamBuildFinder of this type.

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/dbf/DownstreamBuildFinder.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/dbf/DownstreamBuildFinder.java
@@ -26,8 +26,8 @@ package com.sonyericsson.jenkins.plugins.bfa.model.dbf;
 
 import hudson.ExtensionList;
 import hudson.ExtensionPoint;
-import hudson.model.AbstractBuild;
 import hudson.model.Hudson;
+import hudson.model.Run;
 
 import java.util.Collections;
 import java.util.LinkedList;
@@ -38,7 +38,7 @@ import java.util.List;
  * plugin have there own way of keeping this information.
  * <p/>
  * Extend this class and implement
- * {@link #getDownstreamBuilds(hudson.model.AbstractBuild)}
+ * {@link #getDownstreamBuilds(hudson.model.Run)}
  * in a way suitable for the plugin
  *
  * @author Jan-Olof Sivtoft
@@ -49,8 +49,8 @@ public abstract class DownstreamBuildFinder implements ExtensionPoint {
      * No need to create a new empty list each time there is nothing to return.
      * Make it unmodifiable to make sure it isn't used.
      */
-    protected static final List<AbstractBuild<?, ?>> EMPTY =
-            Collections.unmodifiableList(new LinkedList<AbstractBuild<?, ?>>());
+    protected static final List<Run<?, ?>> EMPTY =
+            Collections.unmodifiableList(new LinkedList<Run<?, ?>>());
 
     /**
      * Return a list of all downstream builds originating from provided build.
@@ -58,8 +58,8 @@ public abstract class DownstreamBuildFinder implements ExtensionPoint {
      * @param build get the downstream build(s) relative this build
      * @return a list with downstream builds
      */
-    public abstract List<AbstractBuild<?, ?>> getDownstreamBuilds(
-            final AbstractBuild build);
+    public abstract List<Run<?, ?>> getDownstreamBuilds(
+            final Run build);
 
     /**
      * Return a list of all registered DownstreamBuildFinder of this type.

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/dbf/ParameterizedTriggerDBF.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/dbf/ParameterizedTriggerDBF.java
@@ -25,8 +25,8 @@
 package com.sonyericsson.jenkins.plugins.bfa.model.dbf;
 
 import hudson.Extension;
-import hudson.model.AbstractBuild;
 import hudson.model.Action;
+import hudson.model.Run;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -56,8 +56,8 @@ public class ParameterizedTriggerDBF extends DownstreamBuildFinder {
      * @return a list with downstream builds
      */
     @Override
-    public List<AbstractBuild<?, ?>> getDownstreamBuilds(
-            final AbstractBuild build) {
+    public List<Run<?, ?>> getDownstreamBuilds(
+            final Run build) {
 
         if (build == null) {
             return EMPTY;

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/indication/BuildLogIndication.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/indication/BuildLogIndication.java
@@ -30,10 +30,10 @@ import com.sonyericsson.jenkins.plugins.bfa.model.FailureReader;
 import hudson.Extension;
 import hudson.matrix.MatrixConfiguration;
 import hudson.matrix.MatrixProject;
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
 import hudson.model.Hudson;
 import hudson.model.ItemGroup;
+import hudson.model.Job;
+import hudson.model.Run;
 import hudson.util.FormValidation;
 
 import java.io.IOException;
@@ -119,11 +119,11 @@ public class BuildLogIndication extends Indication {
                  * @param project a project.
                  * @return the build of the given project based on this StringBuildId.
                  *
-                 * @see StringBuildId#getBuild(hudson.model.AbstractProject)
+                 * @see StringBuildId#getBuild(hudson.model.Job)
                  */
                 @Override
-                public AbstractBuild getBuild(AbstractProject<? extends AbstractProject<?, ?>,
-                                        ? extends AbstractBuild<?, ?>> project) {
+                public Run getBuild(Job<? extends Job<?, ?>,
+                                        ? extends Run<?, ?>> project) {
                     return project.getLastBuild();
                 }
             },
@@ -135,11 +135,11 @@ public class BuildLogIndication extends Indication {
                  * @param project a project.
                  * @return the build of the given project based on this StringBuildId.
                  *
-                 * @see StringBuildId#getBuild(hudson.model.AbstractProject)
+                 * @see StringBuildId#getBuild(hudson.model.Job)
                  */
                 @Override
-                public AbstractBuild getBuild(AbstractProject<? extends AbstractProject<?, ?>,
-                        ? extends AbstractBuild<?, ?>> project) {
+                public Run getBuild(Job<? extends Job<?, ?>,
+                        ? extends Run<?, ?>> project) {
                     return project.getLastFailedBuild();
                 }
             },
@@ -151,11 +151,11 @@ public class BuildLogIndication extends Indication {
                  * @param project a project.
                  * @return the build of the given project based on this StringBuildId.
                  *
-                 * @see StringBuildId#getBuild(hudson.model.AbstractProject)
+                 * @see StringBuildId#getBuild(hudson.model.Job)
                  */
                 @Override
-                public AbstractBuild getBuild(AbstractProject<? extends AbstractProject<?, ?>,
-                        ? extends AbstractBuild<?, ?>> project) {
+                public Run getBuild(Job<? extends Job<?, ?>,
+                        ? extends Run<?, ?>> project) {
                     return project.getLastUnsuccessfulBuild();
                 }
             },
@@ -167,11 +167,11 @@ public class BuildLogIndication extends Indication {
                  * @param project a project.
                  * @return the build of the given project based on this StringBuildId.
                  *
-                 * @see StringBuildId#getBuild(hudson.model.AbstractProject)
+                 * @see StringBuildId#getBuild(hudson.model.Job)
                  */
                 @Override
-                public AbstractBuild getBuild(AbstractProject<? extends AbstractProject<?, ?>,
-                        ? extends AbstractBuild<?, ?>> project) {
+                public Run getBuild(Job<? extends Job<?, ?>,
+                        ? extends Run<?, ?>> project) {
                     return project.getLastSuccessfulBuild();
                 }
             };
@@ -223,8 +223,8 @@ public class BuildLogIndication extends Indication {
              * @param project a project.
              * @return the build of the given project based on this StringBuildId.
              */
-            public abstract AbstractBuild getBuild(AbstractProject<? extends AbstractProject<?, ?>,
-                    ? extends AbstractBuild<?, ?>> project);
+            public abstract Run getBuild(Job<? extends Job<?, ?>,
+                    ? extends Run<?, ?>> project);
         }
 
         @Override
@@ -257,7 +257,7 @@ public class BuildLogIndication extends Indication {
                         urlParts[i] = urlMatcher.group(i + 1);
                     }
 
-                    AbstractBuild build = null;
+                    Run build = null;
                     ItemGroup getItemInstance;
 
                     if (urlParts[0].split("/job/").length > 1) {
@@ -271,7 +271,7 @@ public class BuildLogIndication extends Indication {
                          * prefix from where jenkins is served, ie: http://localhost/jenkins/job/<job>/<buildNumber>
                          */
                         String[] interestingJobParts = urlParts[0].split("/job/", 2);
-                        String[] jobParts = interestingJobParts[interestingJobParts.length-1].split("/job/");
+                        String[] jobParts = interestingJobParts[interestingJobParts.length - 1].split("/job/");
                         for (String part: jobParts) {
                             fullFolderName += "/" + part;
                         }
@@ -289,9 +289,9 @@ public class BuildLogIndication extends Indication {
                        Type 3: .../<job>/<buildNumber>/<matrixInfo>/
                      */
 
-                    if (getItemInstance.getItem(urlParts[2]) instanceof AbstractProject
+                    if (getItemInstance.getItem(urlParts[2]) instanceof Job
                             && isValidBuildId(urlParts[3])) {
-                        AbstractProject project = (AbstractProject)getItemInstance.getItem(urlParts[2]);
+                        Job project = (Job)getItemInstance.getItem(urlParts[2]);
                         build = getBuildById(project, urlParts[3]);
                     } else if (getItemInstance.getItem(urlParts[1]) instanceof MatrixProject
                             && isValidBuildId(urlParts[3])) {
@@ -348,8 +348,8 @@ public class BuildLogIndication extends Indication {
          * @return the build defined by the given project and id, or null if no build can be
          * found for the given project and id.
          */
-        private AbstractBuild getBuildById(AbstractProject<? extends AbstractProject<?, ?>,
-                ? extends AbstractBuild<?, ?>> project, String id) {
+        private Run getBuildById(Job<? extends Job<?, ?>,
+                ? extends Run<?, ?>> project, String id) {
             if (id.matches("\\d+")) {
                 return project.getBuildByNumber(Integer.parseInt(id));
             } else {

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/indication/FoundIndication.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/indication/FoundIndication.java
@@ -25,10 +25,10 @@
 package com.sonyericsson.jenkins.plugins.bfa.model.indication;
 
 import com.sonyericsson.jenkins.plugins.bfa.utils.OldDataConverter;
-import hudson.model.AbstractBuild;
 
 import java.util.List;
 
+import hudson.model.Run;
 import org.codehaus.jackson.annotate.JsonCreator;
 import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 import org.codehaus.jackson.annotate.JsonProperty;
@@ -56,7 +56,7 @@ public class FoundIndication {
     @Deprecated
     private transient Integer matchingLine;
     private String pattern;
-    private AbstractBuild build;
+    private Run build;
     private String matchingString;
 
     /**
@@ -67,7 +67,7 @@ public class FoundIndication {
      * @param matchingFile    the path to the file in which we found the match.
      * @param matchingString  the String that makes up the match.
      */
-    public FoundIndication(AbstractBuild build, String originalPattern,
+    public FoundIndication(Run build, String originalPattern,
                            String matchingFile, String matchingString) {
         this.pattern = originalPattern;
         this.matchingFile = matchingFile;
@@ -114,7 +114,7 @@ public class FoundIndication {
      *
      * @return the build.
      */
-    public AbstractBuild getBuild() {
+    public Run getBuild() {
         return build;
     }
 

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/sod/ScanOnDemandBaseAction.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/sod/ScanOnDemandBaseAction.java
@@ -29,10 +29,10 @@ import com.sonyericsson.jenkins.plugins.bfa.model.FailureCauseBuildAction;
 import com.sonyericsson.jenkins.plugins.bfa.model.FailureCauseMatrixBuildAction;
 import hudson.matrix.MatrixBuild;
 import hudson.matrix.MatrixRun;
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
 import hudson.model.Action;
 import hudson.model.Item;
+import hudson.model.Job;
+import hudson.model.Run;
 import hudson.model.Project;
 import hudson.model.Result;
 import hudson.util.RunList;
@@ -55,7 +55,7 @@ import org.kohsuke.stapler.StaplerResponse;
 public class ScanOnDemandBaseAction implements Action {
 
     /** The project. */
-    private AbstractProject project;
+    private Job project;
     /**
      * javascript file location.
      */
@@ -74,7 +74,7 @@ public class ScanOnDemandBaseAction implements Action {
      *
      * @param project current project.
      */
-    public ScanOnDemandBaseAction(final AbstractProject project) {
+    public ScanOnDemandBaseAction(final Job project) {
         this.project = project;
     }
 
@@ -147,7 +147,7 @@ public class ScanOnDemandBaseAction implements Action {
      *
      * @return project
      */
-    public final AbstractProject<?, ?> getProject() {
+    public final Job<?, ?> getProject() {
         return project;
     }
 
@@ -156,14 +156,14 @@ public class ScanOnDemandBaseAction implements Action {
      *
      * @return sodbuilds.
      */
-    public List<AbstractBuild> getAllBuilds() {
-        AbstractProject currentProject = project;
-        List<AbstractBuild> sodbuilds = new ArrayList<AbstractBuild>();
+    public List<Run> getAllBuilds() {
+        Job currentProject = project;
+        List<Run> sodbuilds = new ArrayList<Run>();
         if (currentProject != null) {
             RunList builds = currentProject.getBuilds();
             for (Object build : builds) {
-                if (PluginImpl.needToAnalyze(((AbstractBuild)build).getResult())) {
-                    sodbuilds.add((AbstractBuild)build);
+                if (PluginImpl.needToAnalyze(((Run)build).getResult())) {
+                    sodbuilds.add((Run)build);
                 }
             }
         }
@@ -177,7 +177,7 @@ public class ScanOnDemandBaseAction implements Action {
      * @param scanTarget String.
      * @return builds.
      */
-    public List<AbstractBuild> getBuilds(String scanTarget) {
+    public List<Run> getBuilds(String scanTarget) {
         if (scanTarget != null) {
             setBuildType(scanTarget);
         }
@@ -189,7 +189,7 @@ public class ScanOnDemandBaseAction implements Action {
      *
      * @return builds.
      */
-    public List<AbstractBuild> getBuilds() {
+    public List<Run> getBuilds() {
         buildType = getBuildType();
         if (buildType != null) {
             if (buildType.length() == 0 || buildType.equals(NON_SCANNED)) {
@@ -207,11 +207,11 @@ public class ScanOnDemandBaseAction implements Action {
      *
      * @return sodbuilds.
      */
-    public List<AbstractBuild> getNotScannedBuilds() {
-        List<AbstractBuild> sodbuilds = new ArrayList<AbstractBuild>();
+    public List<Run> getNotScannedBuilds() {
+        List<Run> sodbuilds = new ArrayList<Run>();
         if (project != null) {
-            List<AbstractBuild> builds = project.getBuilds();
-            for (AbstractBuild build : builds) {
+            List<Run> builds = project.getBuilds();
+            for (Run build : builds) {
                 final Result result = build.getResult();
                 if (result != null
                     && PluginImpl.needToAnalyze(result)
@@ -228,7 +228,7 @@ public class ScanOnDemandBaseAction implements Action {
     /**
      * Method for remove matrix run actions.
      *
-     * @param  build AbstractBuild.
+     * @param build the MatrixBuild.
      */
     public void removeRunActions(MatrixBuild build) {
         List<MatrixRun> runs = build.getRuns();
@@ -258,9 +258,9 @@ public class ScanOnDemandBaseAction implements Action {
     public void doPerformScan(StaplerRequest request, StaplerResponse response)
             throws ServletException, IOException, InterruptedException {
         checkPermission();
-        List<AbstractBuild> sodbuilds = getBuilds();
+        List<Run> sodbuilds = getBuilds();
         if (!sodbuilds.isEmpty()) {
-            for (AbstractBuild sodbuild : sodbuilds) {
+            for (Run sodbuild : sodbuilds) {
                 FailureCauseBuildAction fcba = sodbuild.getAction(FailureCauseBuildAction.class);
                 if (fcba != null) {
                     sodbuild.getActions().remove(fcba);

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/sod/ScanOnDemandTransientActionProvider.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/sod/ScanOnDemandTransientActionProvider.java
@@ -25,15 +25,15 @@ package com.sonyericsson.jenkins.plugins.bfa.sod;
 
 import com.sonyericsson.jenkins.plugins.bfa.PluginImpl;
 import hudson.Extension;
-import hudson.model.AbstractProject;
 import hudson.model.Action;
-import hudson.model.TransientProjectActionFactory;
+import hudson.model.Job;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 
 import com.sonyericsson.jenkins.plugins.bfa.graphs.ProjectGraphAction;
+import jenkins.model.TransientActionFactory;
 
 /**
  * Extension point for inserting SOD Transient Actions
@@ -42,10 +42,15 @@ import com.sonyericsson.jenkins.plugins.bfa.graphs.ProjectGraphAction;
  * @author Shemeer Sulaiman &lt;shemeer.x.sulaiman@sonymobile.com&gt;
  */
 @Extension
-public class ScanOnDemandTransientActionProvider extends TransientProjectActionFactory {
+public class ScanOnDemandTransientActionProvider extends TransientActionFactory<Job> {
 
     @Override
-    public Collection<? extends Action> createFor(AbstractProject target) {
+    public Class<Job> type() {
+        return Job.class;
+    }
+
+    @Override
+    public Collection<? extends Action> createFor(Job target) {
         if (PluginImpl.shouldScan(target)) {
             final ScanOnDemandBaseAction sodBaseAction = new ScanOnDemandBaseAction(target);
             final ProjectGraphAction graphAction = new ProjectGraphAction(target);

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/statistics/StatisticsLogger.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/statistics/StatisticsLogger.java
@@ -32,6 +32,7 @@ import com.sonyericsson.jenkins.plugins.bfa.utils.BfaUtils;
 import hudson.model.AbstractBuild;
 import hudson.model.Cause;
 import hudson.model.Node;
+import hudson.model.Run;
 
 import java.util.Date;
 import java.util.LinkedList;
@@ -87,7 +88,7 @@ public final class StatisticsLogger {
      * @param build the build.
      * @param causes the list of causes.
      */
-    public void log(AbstractBuild build, List<FoundFailureCause> causes) {
+    public void log(Run build, List<FoundFailureCause> causes) {
         if (PluginImpl.getInstance().getKnowledgeBase().isStatisticsEnabled()) {
             queueExecutor.submit(new LoggingWork(build, causes));
         }
@@ -99,7 +100,7 @@ public final class StatisticsLogger {
     static class LoggingWork implements Runnable {
 
         List<FoundFailureCause> causes;
-        AbstractBuild build;
+        Run build;
 
         /**
          * Standard Constructor.
@@ -107,14 +108,14 @@ public final class StatisticsLogger {
          * @param build the build to log for.
          * @param causes the causes to log.
          */
-        LoggingWork(AbstractBuild build, List<FoundFailureCause> causes) {
+        LoggingWork(Run build, List<FoundFailureCause> causes) {
             this.build = build;
             this.causes = causes;
         }
 
         @Override
         public void run() {
-            String projectName = build.getProject().getFullName();
+            String projectName = build.getParent().getFullName();
             int buildNumber = build.getNumber();
             String displayName = build.getDisplayName();
             Date startingTime = build.getTime();
@@ -123,8 +124,12 @@ public final class StatisticsLogger {
             for (Object o : build.getCauses()) {
                 triggerCauses.add(o.getClass().getSimpleName());
             }
-            Node node = build.getBuiltOn();
-            String nodeName = node.getNodeName();
+            String nodeName = "NoNodeInformation";
+            if (build instanceof AbstractBuild) {
+                AbstractBuild abstractBuild = (AbstractBuild)build;
+                Node node = abstractBuild.getBuiltOn();
+                nodeName = node.getNodeName();
+            }
             int timeZoneOffset = TimeZone.getDefault().getRawOffset();
             String master;
 

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/utils/OldDataConverter.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/utils/OldDataConverter.java
@@ -30,7 +30,7 @@ import com.sonyericsson.jenkins.plugins.bfa.model.FoundFailureCause;
 import com.sonyericsson.jenkins.plugins.bfa.model.indication.FoundIndication;
 
 import hudson.Extension;
-import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import hudson.model.listeners.ItemListener;
 
 import java.io.IOException;
@@ -76,7 +76,7 @@ public final class OldDataConverter extends ItemListener {
     private static OldDataConverter instance;
 
 
-    private Set<AbstractBuild> performedBuilds;
+    private Set<Run> performedBuilds;
     private Map<String, List<FailureCauseMatrixBuildAction>> actionsToConvert;
     private ScheduledThreadPoolExecutor executor;
     //Has the call from Jenkins arrived that all items are loaded?
@@ -102,7 +102,7 @@ public final class OldDataConverter extends ItemListener {
      * Default Constructor. <strong>Should only be instantiated by Jenkins</strong>
      */
     public OldDataConverter() {
-        performedBuilds = Collections.synchronizedSet(new HashSet<AbstractBuild>());
+        performedBuilds = Collections.synchronizedSet(new HashSet<Run>());
         actionsToConvert = Collections.synchronizedMap(new HashMap<String, List<FailureCauseMatrixBuildAction>>());
         executor = (ScheduledThreadPoolExecutor)Executors.newScheduledThreadPool(POOL_SIZE);
     }
@@ -113,7 +113,7 @@ public final class OldDataConverter extends ItemListener {
      *
      * @param build the build to convert.
      */
-    public void convertFoundIndications(AbstractBuild build) {
+    public void convertFoundIndications(Run build) {
         //Just a convenience first check, because of the delay in scheduling
         // we will still get the same build multiple times in the executor, but the run method takes care of that.
         if (!performedBuilds.contains(build)) {
@@ -210,8 +210,8 @@ public final class OldDataConverter extends ItemListener {
      * A work task that does the actual conversion in an executor thread.
      */
     public static class FoundIndicationWork implements Runnable {
-        private AbstractBuild build;
-        private Set<AbstractBuild> performedBuilds;
+        private Run build;
+        private Set<Run> performedBuilds;
 
         /**
          * Standard Constructor.
@@ -219,7 +219,7 @@ public final class OldDataConverter extends ItemListener {
          * @param build           the build to convert.
          * @param performedBuilds the list of in-progress or already converted builds.
          */
-        public FoundIndicationWork(AbstractBuild build, Set<AbstractBuild> performedBuilds) {
+        public FoundIndicationWork(Run build, Set<Run> performedBuilds) {
             this.build = build;
             this.performedBuilds = performedBuilds;
         }

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/FailureCauseWorkFlowTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/FailureCauseWorkFlowTest.java
@@ -1,0 +1,85 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2016 Sony Mobile Communications Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.sonyericsson.jenkins.plugins.bfa;
+
+import com.sonyericsson.jenkins.plugins.bfa.model.FailureCauseBuildAction;
+import hudson.model.Result;
+import org.hamcrest.Matchers;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import java.util.concurrent.Future;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+//CS IGNORE MagicNumber FOR NEXT 100 LINES. REASON: TestData.
+
+/**
+ * Tests for WorkflowJobs.
+ * @author Tomas Westling &lt;tomas.westling@sonymobile.com&gt;
+ * @throws Exception if so.
+ */
+public class FailureCauseWorkFlowTest {
+    /**
+     * The Jenkins Rule.
+     */
+    @Rule
+    //CS IGNORE VisibilityModifier FOR NEXT 1 LINES. REASON: Jenkins Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    /**
+     * Tests that an action is added when the builds fail.
+     *
+     * @throws Exception if so.
+     */
+    @Test
+    public void testWorkflowFailureCauseBuildAction() throws Exception {
+        WorkflowJob proj = j.jenkins.createProject(WorkflowJob.class, "proj");
+        proj.setDefinition(new CpsFlowDefinition("error()"));
+        Future<WorkflowRun> f = proj.scheduleBuild2(0);
+        assertThat("build was actually scheduled", f, Matchers.notNullValue());
+        WorkflowRun run = j.assertBuildStatus(Result.FAILURE, f.get());
+        FailureCauseBuildAction action = run.getAction(FailureCauseBuildAction.class);
+        assertNotNull(action);
+    }
+
+    /**
+     * Tests that no action is added if all builds are successful.
+     *
+     * @throws Exception if so.
+     */
+    @Test
+    public void testFailureCausesWhenNotFailed() throws Exception {
+        WorkflowJob proj = j.jenkins.createProject(WorkflowJob.class, "proj");
+        proj.setDefinition(new CpsFlowDefinition("println('hello')"));
+        WorkflowRun run = j.assertBuildStatusSuccess(proj.scheduleBuild2(0));
+        FailureCauseBuildAction action = run.getAction(FailureCauseBuildAction.class);
+        assertNull(action);
+    }
+}

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureReaderTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureReaderTest.java
@@ -42,7 +42,7 @@ import com.sonyericsson.jenkins.plugins.bfa.model.indication.BuildLogIndication;
 import com.sonyericsson.jenkins.plugins.bfa.model.indication.FoundIndication;
 import com.sonyericsson.jenkins.plugins.bfa.model.indication.Indication;
 import com.sonyericsson.jenkins.plugins.bfa.model.indication.MultilineBuildLogIndication;
-import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import org.junit.Test;
 
 
@@ -69,12 +69,12 @@ public class FailureReaderTest {
         }
 
         @Override
-        public FoundIndication scan(AbstractBuild build) throws IOException {
+        public FoundIndication scan(Run build) throws IOException {
             return null;
         }
 
         @Override
-        public FoundIndication scan(AbstractBuild build, PrintStream buildLog) {
+        public FoundIndication scan(Run build, PrintStream buildLog) {
             return null;
         }
     }


### PR DESCRIPTION
With this change, Pipeline projects are analyzed
by the BFA. The major change was changing AbstractBuild
to Run and AbstractProject to Job, which would also make
other project and build types that aren't AbstractBuild/Project
start working with the BFA.

Some issues remain and should be fixed in future changes:
Downstream builds linking. If a Pipeline project starts downstream builds
which fail, these won't be shown on the Pipeline build page.

"Built on". In the statistics logging, adding which node the Pipeline
run was run on doesn't work. A Pipeline project could use many nodes
and a new structure for this in the statistics must be created.

TokenMacro plugin integration. The TokenMacro evaluation uses AbstractBuild.
This needs to be changed to Run in the TokenMacro plugin in order for the
evaluation to work with Pipeline runs.

Change-Id: I2a0debed0a13c051d3614c5ceece77a31232ac3d