### PR TITLE
Fix gerrit feedback for nested builds

### DIFF
--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/BuildFailureScanner.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/BuildFailureScanner.java
@@ -180,21 +180,19 @@ public class BuildFailureScanner extends RunListener<Run> {
      * @param downstreamFailureCauses the list of downstream failure causes.
      */
     private static void printDownstream(PrintStream buildLog, List<FailureCauseDisplayData> downstreamFailureCauses) {
-        if (!downstreamFailureCauses.isEmpty()) {
-            for (FailureCauseDisplayData displayData : downstreamFailureCauses) {
-                FailureCauseDisplayData.Links links = displayData.getLinks();
-                if (!displayData.getFoundFailureCauses().isEmpty()) {
-                    buildLog.println("[BFA] See: " + Jenkins.getInstance().getRootUrl() + links.getBuildUrl());
-                    for (FoundFailureCause foundCause : displayData.getFoundFailureCauses()) {
-                        String foundString = "[BFA] " + foundCause.getName();
-                        if (foundCause.getCategories() != null) {
-                            foundString += " from category " + foundCause.getCategories().get(0);
-                        }
-                        buildLog.println(foundString);
+        for (FailureCauseDisplayData displayData : downstreamFailureCauses) {
+            FailureCauseDisplayData.Links links = displayData.getLinks();
+            if (!displayData.getFoundFailureCauses().isEmpty()) {
+                buildLog.println("[BFA] See: " + Jenkins.getInstance().getRootUrl() + links.getBuildUrl());
+                for (FoundFailureCause foundCause : displayData.getFoundFailureCauses()) {
+                    String foundString = "[BFA] " + foundCause.getName();
+                    if (foundCause.getCategories() != null) {
+                        foundString += " from category " + foundCause.getCategories().get(0);
                     }
+                    buildLog.println(foundString);
                 }
-                printDownstream(buildLog, displayData.getDownstreamFailureCauses());
             }
+            printDownstream(buildLog, displayData.getDownstreamFailureCauses());
         }
     }
 

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/BuildFailureScanner.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/BuildFailureScanner.java
@@ -57,6 +57,7 @@ import hudson.model.TaskListener;
 import hudson.model.listeners.RunListener;
 import hudson.tasks.test.AbstractTestResultAction;
 import hudson.tasks.test.TestResult;
+import jenkins.model.Jenkins;
 
 /**
  * Looks for Indications, trying to find the Cause of a problem.
@@ -161,22 +162,39 @@ public class BuildFailureScanner extends RunListener<Run> {
 
             if (!downstreamFailureCauses.isEmpty()) {
                 buildLog.println("[BFA] Found downstream Failure causes ...");
-                for (FailureCauseDisplayData displayData : downstreamFailureCauses) {
-                  FailureCauseDisplayData.Links links = displayData.getLinks();
-                  buildLog.println("[BFA] See " + links.getProjectDisplayName() + links.getBuildDisplayName());
-                  List<FoundFailureCause> failureCauses = displayData.getFoundFailureCauses();
-                  for (FoundFailureCause foundCause : failureCauses) {
-                    String foundString = "[BFA] " + foundCause.getName();
-                    if (foundCause.getCategories() != null) {
-                        foundString += " from category " + foundCause.getCategories().get(0);
-                    }
-                    buildLog.println(foundString);
-                    }
-                }
+                printDownstream(buildLog, downstreamFailureCauses);
             }
+
             StatisticsLogger.getInstance().log(build, foundCauseListToLog);
         } catch (Exception e) {
             logger.log(Level.SEVERE, "Could not scan build " + build, e);
+        }
+    }
+
+
+    /**
+     *
+     * Adds all causes from downstream builds in recursion
+     *
+     * @param buildLog log to write information to.
+     * @param downstreamFailureCauses the list of downstream failure causes.
+     */
+    private static void printDownstream(PrintStream buildLog, List<FailureCauseDisplayData> downstreamFailureCauses) {
+        if (!downstreamFailureCauses.isEmpty()) {
+            for (FailureCauseDisplayData displayData : downstreamFailureCauses) {
+                FailureCauseDisplayData.Links links = displayData.getLinks();
+                if (!displayData.getFoundFailureCauses().isEmpty()) {
+                    buildLog.println("[BFA] See: " + Jenkins.getInstance().getRootUrl() + links.getBuildUrl());
+                    for (FoundFailureCause foundCause : displayData.getFoundFailureCauses()) {
+                        String foundString = "[BFA] " + foundCause.getName();
+                        if (foundCause.getCategories() != null) {
+                            foundString += " from category " + foundCause.getCategories().get(0);
+                        }
+                        buildLog.println(foundString);
+                    }
+                }
+                printDownstream(buildLog, displayData.getDownstreamFailureCauses());
+            }
         }
     }
 
@@ -296,7 +314,7 @@ public class BuildFailureScanner extends RunListener<Run> {
      *
      * @param build    the build to analyze.
      * @param buildLog the build log.
-     * @return a list of found failure causes based on the test results
+     * @return a list of found failure causes based on the test results.
      */
     private static List<FoundFailureCause> findFailedTests(final Run build, final PrintStream buildLog) {
         final List<FoundFailureCause> failedTestList =

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/GerritMessageProviderExtension.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/GerritMessageProviderExtension.java
@@ -56,7 +56,7 @@ public class GerritMessageProviderExtension extends GerritMessageProvider {
                     printDownstream(customMessage, displayData.getDownstreamFailureCauses());
 
                     if (customMessage.length() > 0) {
-                        return customMessage.toString().replace("'", "&#39");
+                        return customMessage.toString().replace("'", "\"");
                     }
                 }
             }

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCauseBuildAction.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCauseBuildAction.java
@@ -30,8 +30,8 @@ import com.sonyericsson.jenkins.plugins.bfa.PluginImpl;
 import com.sonyericsson.jenkins.plugins.bfa.model.dbf.DownstreamBuildFinder;
 import hudson.matrix.MatrixRun;
 import hudson.model.BuildBadgeAction;
-import hudson.model.Hudson;
 import hudson.model.Run;
+import jenkins.model.Jenkins;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.export.Exported;
@@ -73,7 +73,7 @@ public class FailureCauseBuildAction implements BuildBadgeAction {
 
     @Override
     public String getIconFileName() {
-        if (Hudson.getInstance().hasPermission(PluginImpl.UPDATE_PERMISSION)) {
+        if (Jenkins.getInstance().hasPermission(PluginImpl.UPDATE_PERMISSION)) {
             return PluginImpl.getDefaultIcon();
         } else {
             return null;
@@ -82,7 +82,7 @@ public class FailureCauseBuildAction implements BuildBadgeAction {
 
     @Override
     public String getDisplayName() {
-        if (Hudson.getInstance().hasPermission(PluginImpl.UPDATE_PERMISSION)) {
+        if (Jenkins.getInstance().hasPermission(PluginImpl.UPDATE_PERMISSION)) {
             return Messages.CauseManagement_DisplayName();
         } else {
             return null;
@@ -237,7 +237,11 @@ public class FailureCauseBuildAction implements BuildBadgeAction {
         FailureCauseDisplayData displayData = null;
         // Preventing us to get into a recursive loop
         if (depth < maxDepth && buildAction.getBuild() != null) {
-            displayData = new FailureCauseDisplayData(buildAction.getBuild());
+            Run build = buildAction.getBuild();
+            displayData = new FailureCauseDisplayData(build.getParent().getUrl(),
+                    build.getParent().getDisplayName(),
+                    build.getUrl(),
+                    build.getDisplayName());
 
             // Add causes from this build
             displayData.setFoundFailureCauses(

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCauseDisplayData.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCauseDisplayData.java
@@ -23,7 +23,6 @@ package com.sonyericsson.jenkins.plugins.bfa.model;
  * THE SOFTWARE.
  */
 
-import hudson.model.Run;
 import org.kohsuke.stapler.export.ExportedBean;
 
 import java.util.LinkedList;
@@ -52,10 +51,14 @@ public class FailureCauseDisplayData {
     /**
      * Use this constructor when the build is known.
      *
-     * @param build corresponding build
+     * @param parentUrl url of the parent job.
+     * @param parentName name of the parent job.
+     * @param buildUrl url of the build.
+     * @param buildName name of the build.
+     *
      */
-    public FailureCauseDisplayData(final Run build) {
-        links = new Links(build);
+    public FailureCauseDisplayData(final String parentUrl, final String parentName, final String buildUrl, final String buildName) {
+        links = new Links(parentUrl, parentName, buildUrl, buildName);
     }
 
     /**
@@ -121,13 +124,16 @@ public class FailureCauseDisplayData {
          *
          * Url to the project and the build will be displayed in the view.
          *
-         * @param build - the build to extract link info from
+         * @param parentUrl url of the parent job.
+         * @param parentName name of the parent job.
+         * @param buildUrl url of the build.
+         * @param buildName name of the build.
          */
-        private Links(final Run build) {
-            this.projectUrl = build.getParent().getUrl();
-            this.buildUrl = build.getUrl();
-            this.projectDisplayName = build.getParent().getDisplayName();
-            this.buildDisplayName = build.getDisplayName();
+        private Links(final String parentUrl, final String parentName, final String buildUrl, final String buildName) {
+            this.projectUrl = parentUrl;
+            this.buildUrl = buildUrl;
+            this.projectDisplayName = parentName;
+            this.buildDisplayName = buildName;
         }
 
         /**

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCauseDisplayData.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCauseDisplayData.java
@@ -23,6 +23,7 @@ package com.sonyericsson.jenkins.plugins.bfa.model;
  * THE SOFTWARE.
  */
 
+import hudson.model.Run;
 import org.kohsuke.stapler.export.ExportedBean;
 
 import java.util.LinkedList;
@@ -51,13 +52,30 @@ public class FailureCauseDisplayData {
     /**
      * Use this constructor when the build is known.
      *
+     * @param build corresponding build.
+     *
+     */
+    @Deprecated
+    public FailureCauseDisplayData(final Run build) {
+        links = new Links(build.getParent().getUrl(),
+                build.getParent().getDisplayName(),
+                build.getUrl(),
+                build.getDisplayName());
+    }
+
+    /**
+     * Use this constructor when the build is known.
+     *
      * @param parentUrl url of the parent job.
      * @param parentName name of the parent job.
      * @param buildUrl url of the build.
      * @param buildName name of the build.
      *
      */
-    public FailureCauseDisplayData(final String parentUrl, final String parentName, final String buildUrl, final String buildName) {
+    public FailureCauseDisplayData(final String parentUrl,
+                                   final String parentName,
+                                   final String buildUrl,
+                                   final String buildName) {
         links = new Links(parentUrl, parentName, buildUrl, buildName);
     }
 
@@ -129,7 +147,10 @@ public class FailureCauseDisplayData {
          * @param buildUrl url of the build.
          * @param buildName name of the build.
          */
-        private Links(final String parentUrl, final String parentName, final String buildUrl, final String buildName) {
+        private Links(final String parentUrl,
+                      final String parentName,
+                      final String buildUrl,
+                      final String buildName) {
             this.projectUrl = parentUrl;
             this.buildUrl = buildUrl;
             this.projectDisplayName = parentName;

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/BuildFailureScannerHudsonTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/BuildFailureScannerHudsonTest.java
@@ -276,7 +276,7 @@ public class BuildFailureScannerHudsonTest {
 
         assertEquals("The " + GerritMessageProviderExtension.class.getSimpleName()
                 + " extension would not return the expected message.",
-                FORMATTED_DESCRIPTION + " ( " + Jenkins.getInstance().getRootUrl() + "/job/test0/1/ )",
+                FORMATTED_DESCRIPTION + " ( " + Jenkins.getInstance().getRootUrl() + "job/test0/1/ )",
                 messageProvider.getBuildCompletedMessage(build));
 
         PluginImpl.getInstance().setGerritTriggerEnabled(false);

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/GerritMessageProviderExtensionTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/GerritMessageProviderExtensionTest.java
@@ -2,7 +2,9 @@ package com.sonyericsson.jenkins.plugins.bfa;
 
 import com.sonyericsson.jenkins.plugins.bfa.model.FailureCause;
 import com.sonyericsson.jenkins.plugins.bfa.model.FailureCauseBuildAction;
+import com.sonyericsson.jenkins.plugins.bfa.model.FailureCauseDisplayData;
 import com.sonyericsson.jenkins.plugins.bfa.model.FoundFailureCause;
+import hudson.model.Job;
 import hudson.model.Run;
 import jenkins.model.Jenkins;
 import org.junit.Assert;
@@ -42,7 +44,72 @@ public class GerritMessageProviderExtensionTest {
         PluginImpl plugin = PowerMockito.mock(PluginImpl.class);
         PowerMockito.when(plugin.isGerritTriggerEnabled()).thenReturn(true);
         PowerMockito.when(PluginImpl.getInstance()).thenReturn(plugin);
+    }
 
+    /**
+     *
+     * Creates run with desired failure cause
+     *
+     * @param cause failure cause that would be displayed.
+     * @return Run with desired failure cause.
+     */
+    private Run getRunWithTopCause(String cause) {
+        Run run = PowerMockito.mock(Run.class);
+        Job parent = PowerMockito.mock(Job.class);
+        FailureCauseBuildAction action = PowerMockito.mock(FailureCauseBuildAction.class);
+
+        List<FoundFailureCause> failureCauses = new ArrayList<FoundFailureCause>();
+        failureCauses.add(new FoundFailureCause(new FailureCause("testName", cause)));
+        FailureCauseDisplayData displayData = new FailureCauseDisplayData("parentURL", "parentName",
+                "/jobs/build/123", "buildName");
+        displayData.setFoundFailureCauses(failureCauses);
+
+        PowerMockito.when(run.getAction(FailureCauseBuildAction.class)).thenReturn(action);
+        PowerMockito.when(run.getUrl()).thenReturn(BUILD_URL);
+        PowerMockito.when(run.getParent()).thenReturn(parent);
+        PowerMockito.when(action.getBuild()).thenReturn(run);
+        PowerMockito.when(action.getFailureCauseDisplayData()).thenReturn(displayData);
+
+        return run;
+    }
+
+    /**
+     *
+     * Creates run with desired failure cause on third level
+     *
+     * @param cause failure cause that would be displayed.
+     * @return Run with desired failure cause in third level.
+     */
+    private Run getRunWithDeepCause(String cause) {
+        Run run = PowerMockito.mock(Run.class);
+        Job parent = PowerMockito.mock(Job.class);
+        FailureCauseBuildAction action = PowerMockito.mock(FailureCauseBuildAction.class);
+
+        List<FoundFailureCause> emptyFailureCauses = new ArrayList<FoundFailureCause>();
+        List<FoundFailureCause> failureCauses = new ArrayList<FoundFailureCause>();
+        failureCauses.add(new FoundFailureCause(new FailureCause("testName", cause)));
+
+        FailureCauseDisplayData bottomDisplayData = new FailureCauseDisplayData("parentURL", "bottomBuildName",
+                "/jobs/build/789", "bottomBuildName");
+        bottomDisplayData.setFoundFailureCauses(failureCauses);
+
+        FailureCauseDisplayData middleDisplayData = new FailureCauseDisplayData("parentURL", "middleBuildName",
+                "/jobs/build/456", "middleBuildName");
+        middleDisplayData.setFoundFailureCauses(emptyFailureCauses);
+        middleDisplayData.addDownstreamFailureCause(bottomDisplayData);
+
+        FailureCauseDisplayData topLevelDisplayData = new FailureCauseDisplayData("topParentURL", "topParentName",
+                "/jobs/build/123", "topBuildName");
+        topLevelDisplayData.setFoundFailureCauses(emptyFailureCauses);
+        topLevelDisplayData.addDownstreamFailureCause(middleDisplayData);
+
+        PowerMockito.when(run.getAction(FailureCauseBuildAction.class)).thenReturn(action);
+        PowerMockito.when(run.getUrl()).thenReturn(BUILD_URL);
+        PowerMockito.when(run.getParent()).thenReturn(parent);
+        PowerMockito.when(action.getBuild()).thenReturn(run);
+        PowerMockito.when(action.getFailureCauseDisplayData()).thenReturn(topLevelDisplayData);
+
+        return run;
     }
 
     /**
@@ -50,18 +117,11 @@ public class GerritMessageProviderExtensionTest {
      */
     @Test
     public void testSingleQuote() {
-        Run run = PowerMockito.mock(Run.class);
-
-        List<FoundFailureCause> failureCauses = new ArrayList<FoundFailureCause>();
-        failureCauses.add(new FoundFailureCause(new FailureCause("testName", "it's a single quote")));
-        FailureCauseBuildAction action = new FailureCauseBuildAction(failureCauses);
-
-        PowerMockito.when(run.getAction(FailureCauseBuildAction.class)).thenReturn(action);
-        PowerMockito.when(run.getUrl()).thenReturn(BUILD_URL);
+        Run run = getRunWithTopCause("it's a single quote");
 
         GerritMessageProviderExtension extension = new GerritMessageProviderExtension();
 
-        Assert.assertEquals("it\\'s a single quote ( http://some.jenkins.com/jobs/build/123 )",
+        Assert.assertEquals("it&#39s a single quote ( http://some.jenkins.com/jobs/build/123 )",
                 extension.getBuildCompletedMessage(run));
     }
 
@@ -70,18 +130,37 @@ public class GerritMessageProviderExtensionTest {
      */
     @Test
     public void testMultipleQuotes() {
-        Run run = PowerMockito.mock(Run.class);
-
-        List<FoundFailureCause> failureCauses = new ArrayList<FoundFailureCause>();
-        failureCauses.add(new FoundFailureCause(new FailureCause("testName", "s'e'v'e'r'a'l q'u'o't'e's")));
-        FailureCauseBuildAction action = new FailureCauseBuildAction(failureCauses);
-
-        PowerMockito.when(run.getAction(FailureCauseBuildAction.class)).thenReturn(action);
-        PowerMockito.when(run.getUrl()).thenReturn(BUILD_URL);
+        Run run = getRunWithTopCause("q'u'o't'e's");
 
         GerritMessageProviderExtension extension = new GerritMessageProviderExtension();
 
-        Assert.assertEquals("s\\'e\\'v\\'e\\'r\\'a\\'l q\\'u\\'o\\'t\\'e\\'s ( http://some.jenkins.com/jobs/build/123 )",
+        Assert.assertEquals("q&#39u&#39o&#39t&#39e&#39s ( http://some.jenkins.com/jobs/build/123 )",
+                extension.getBuildCompletedMessage(run));
+    }
+
+    /**
+     * Test that message from top build would be displayed.
+     */
+    @Test
+    public void testTopCause() {
+        Run run = getRunWithTopCause("some cause");
+
+        GerritMessageProviderExtension extension = new GerritMessageProviderExtension();
+
+        Assert.assertEquals("some cause ( http://some.jenkins.com/jobs/build/123 )",
+                extension.getBuildCompletedMessage(run));
+    }
+
+    /**
+     * Test that message from nested build would be displayed.
+     */
+    @Test
+    public void testDeepCause() {
+        Run run = getRunWithDeepCause("deep cause");
+
+        GerritMessageProviderExtension extension = new GerritMessageProviderExtension();
+
+        Assert.assertEquals("deep cause ( http://some.jenkins.com/jobs/build/789 )",
                 extension.getBuildCompletedMessage(run));
     }
 }

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/GerritMessageProviderExtensionTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/GerritMessageProviderExtensionTest.java
@@ -121,7 +121,7 @@ public class GerritMessageProviderExtensionTest {
 
         GerritMessageProviderExtension extension = new GerritMessageProviderExtension();
 
-        Assert.assertEquals("it&#39s a single quote ( http://some.jenkins.com/jobs/build/123 )",
+        Assert.assertEquals("it\"s a single quote ( http://some.jenkins.com/jobs/build/123 )",
                 extension.getBuildCompletedMessage(run));
     }
 
@@ -134,7 +134,7 @@ public class GerritMessageProviderExtensionTest {
 
         GerritMessageProviderExtension extension = new GerritMessageProviderExtension();
 
-        Assert.assertEquals("q&#39u&#39o&#39t&#39e&#39s ( http://some.jenkins.com/jobs/build/123 )",
+        Assert.assertEquals("q\"u\"o\"t\"e\"s ( http://some.jenkins.com/jobs/build/123 )",
                 extension.getBuildCompletedMessage(run));
     }
 


### PR DESCRIPTION
Before BFA parsed only top level build and first nested build. This
commit introduces recursion for parsing all downstream builds.

I wrote unit tests to verify this behaviour on GerritMessageProviderExtension side.

Also I fixed a bug introduced in my previous PR (https://github.com/jenkinsci/build-failure-analyzer-plugin/pull/54/files#diff-9bf284a9e0f5bafa28fce3ecc91c362aR84): gerrit used run url from top build - instead of build there error occurs.
And implemented new replacement for single comma `. Not it's replaced on equal HTML code.

p.s. I created this PR to show that my previous fix didn't help and even make some stuff worse. I tested it in non-production environment and didn't notice it. So, in case of this PR I think we need to wait at least Monday then I will have some feedback from our production Jenkins as well.