### PR TITLE
Fix line break

### DIFF
--- a/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/PluginImpl/config.properties
+++ b/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/PluginImpl/config.properties
@@ -1,5 +1,4 @@
-enableGerritTriggerDescription=This option allows BFA to forward the description of the found causes \
-to the Gerrit-Trigger-plugin, ultimately allowing users to see their build issues directly inside Gerrit.
+enableGerritTriggerDescription=This option allows BFA to forward the description of the found causes to the Gerrit-Trigger-plugin, ultimately allowing users to see their build issues directly inside Gerrit.
 nrOfScanThreadsDescription=Number of threads per build to use when scanning the failed builds.
 testResultParsingEnabledDescription=Treat failed test cases (as indicated by JUnit/xUnit/... publishers) as failure causes.
 testResultCategoriesDescription=A space-separated list of categories to use for failure causes representing failed test cases.


### PR DESCRIPTION
The displayed message in the configuration screen doesn't show the blank between the 2 words before and after the line break ("...found causesto the Gerrit-Trigger-plugin..."). Interestingly enough, I fixed a similar issue in Eclipse JDT code recently, so maybe the behaviour of the JVM changed here?