### PR TITLE
MultiLineBuildLogIndication performance and bug fixes

### DIFF
--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureReader.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureReader.java
@@ -67,7 +67,7 @@ public abstract class FailureReader {
      *
      * Can never be larger than BUF_SIZE_BYTES.
      */
-    private static int OVERLAP_BYTES = 5000;
+    private static final int OVERLAP_BYTES = 5000;
 
     /**
      * The read buffer size for scanMultiLineOneFile(). This is also the size
@@ -75,7 +75,7 @@ public abstract class FailureReader {
      * the buildlog. Used when scanning for
      * {@link com.sonyericsson.jenkins.plugins.bfa.model.indication.MultilineBuildLogIndication}.
      */
-    private static int BUF_SIZE_BYTES = 15000;
+    private static final int BUF_SIZE_BYTES = 15000;
 
     /** The indication we are looking for. */
     protected Indication indication;
@@ -228,6 +228,7 @@ public abstract class FailureReader {
             StringBuilder searchBuffer = new StringBuilder();
             int read;
             boolean firstRead = true;
+            //CS IGNORE AvoidInlineConditionals FOR NEXT 1 LINES. REASON: Split up makes code less reasable.
             while ((read = reader.read(buf, 0, BUF_SIZE_BYTES - (firstRead ? 0 : OVERLAP_BYTES))) != -1) {
                 try {
                     firstRead = false;

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureReader.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureReader.java
@@ -232,9 +232,9 @@ public abstract class FailureReader {
                 try {
                     firstRead = false;
                     searchBuffer.append(buf, 0, read);
-                    Matcher matcher = pattern.matcher(searchBuffer.toString());
+                    Matcher matcher = pattern.matcher(new InterruptibleCharSequence(searchBuffer.toString()));
                     if (matcher.find()) {
-                        foundIndication = new FoundIndication(build, indication.getUserProvidedExpression(), currentFile,
+                        foundIndication = new FoundIndication(build, pattern.pattern(), currentFile,
                                 removeConsoleNotes(matcher.group()));
                         break;
                     }

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/indication/BuildLogIndication.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/indication/BuildLogIndication.java
@@ -35,15 +35,15 @@ import hudson.model.ItemGroup;
 import hudson.model.Job;
 import hudson.model.Run;
 import hudson.util.FormValidation;
+import jenkins.model.Jenkins;
+import org.codehaus.jackson.annotate.JsonProperty;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
 
 import java.io.IOException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
-
-import jenkins.model.Jenkins;
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.QueryParameter;
 
 /**
  * Indication that parses the build log file for a pattern.
@@ -61,7 +61,7 @@ public class BuildLogIndication extends Indication {
      * @param pattern the string value to search for.
      */
     @DataBoundConstructor
-    public BuildLogIndication(String pattern) {
+    public BuildLogIndication(@JsonProperty("pattern") String pattern) {
         super(pattern);
     }
 

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/indication/Indication.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/indication/Indication.java
@@ -70,7 +70,7 @@ public abstract class Indication implements Describable<Indication>, Serializabl
     /**
      * @return The user-provided regular expression.
      */
-    @JsonIgnore
+    @JsonProperty("pattern")
     public String getUserProvidedExpression() {
         return pattern;
     }
@@ -98,6 +98,7 @@ public abstract class Indication implements Describable<Indication>, Serializabl
      *
      * @return the pattern to match.
      */
+    @JsonIgnore
     public abstract Pattern getPattern();
 
     @Override

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/indication/MultilineBuildLogIndication.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/indication/MultilineBuildLogIndication.java
@@ -23,13 +23,15 @@
  */
 package com.sonyericsson.jenkins.plugins.bfa.model.indication;
 
-import java.util.regex.Pattern;
 import com.sonyericsson.jenkins.plugins.bfa.Messages;
 import com.sonyericsson.jenkins.plugins.bfa.model.FailureReader;
 import com.sonyericsson.jenkins.plugins.bfa.model.MultilineBuildLogFailureReader;
 import hudson.Extension;
 import hudson.model.Hudson;
+import org.codehaus.jackson.annotate.JsonProperty;
 import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.util.regex.Pattern;
 
 /**
  * Build log indication that matches over multiple lines.
@@ -47,7 +49,7 @@ public class MultilineBuildLogIndication extends BuildLogIndication {
      * @param pattern the string value to search for.
      */
     @DataBoundConstructor
-    public MultilineBuildLogIndication(String pattern) {
+    public MultilineBuildLogIndication(@JsonProperty("pattern") String pattern) {
         super(pattern);
     }
 

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/indication/MultilineBuildLogIndication.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/indication/MultilineBuildLogIndication.java
@@ -68,7 +68,8 @@ public class MultilineBuildLogIndication extends BuildLogIndication {
     @Override
     public Pattern getPattern() {
         if (compiled == null) {
-            compiled = Pattern.compile("(?m)(?s)^[\\r\\n]*?" + getUserProvidedExpression() + "[^\\r\\n]*?$");
+            compiled = Pattern.compile("^[^\\r\\n]*?" + getUserProvidedExpression() + "[^\\r\\n]*?$",
+                Pattern.MULTILINE | Pattern.DOTALL);
         }
         return compiled;
     }

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/indication/MultilineBuildLogIndication.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/indication/MultilineBuildLogIndication.java
@@ -68,7 +68,7 @@ public class MultilineBuildLogIndication extends BuildLogIndication {
     @Override
     public Pattern getPattern() {
         if (compiled == null) {
-            compiled = Pattern.compile("^[^\\r\\n]*?" + getUserProvidedExpression() + "[^\\r\\n]*?$",
+            compiled = Pattern.compile("(?m)(?s)^[^\\r\\n]*?" + getUserProvidedExpression() + "[^\\r\\n]*?$",
                 Pattern.MULTILINE | Pattern.DOTALL);
         }
         return compiled;

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureReaderTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureReaderTest.java
@@ -155,23 +155,21 @@ public class FailureReaderTest {
     }
 
     /**
-     * Test of timeout on abusive line. Should timeout on two lines
-     * each timeout between 1 and 2 seconds.
+     * Test of timeout on abusive line.
      * @throws Exception if so
      */
     @Test
-    public void testScanMultiLineOneFileWithLineTimeout() throws Exception {
-        FailureReader reader = new TestReader(new MultilineBuildLogIndication(".*scan for me please.*"));
-        InputStream resStream = this.getClass().getResourceAsStream("FailureReaderTest.zip");
-        ZipInputStream zipStream = new ZipInputStream(resStream);
-        zipStream.getNextEntry();
-        BufferedReader br = new QuadrupleDupleLineReader(new BufferedReader(new InputStreamReader(zipStream)));
+    public void testScanMultiLineOneFileWithBlockTimeout() throws Exception {
+        // Evil input + expression. Will timeout every time.
+        FailureReader reader = new TestReader(new MultilineBuildLogIndication("^(([a-z])+.)+[A-Z]([a-z])+$"));
+        BufferedReader br = new BufferedReader(new InputStreamReader(
+                new ByteArrayInputStream("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".getBytes())));
         long startTime = System.currentTimeMillis();
         FoundIndication indication = reader.scanMultiLineOneFile(null, br, "test");
         long elapsedTime = System.currentTimeMillis() - startTime;
         br.close();
         assertTrue("Unexpected time to parse log: " + elapsedTime, elapsedTime <= 5000);
-        assertNotNull("Expected to find an indication", indication);
+        assertNull("Did not expect to find an indication", indication);
     }
 
     /**

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/model/indication/MultilineBuildLogIndicationTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/model/indication/MultilineBuildLogIndicationTest.java
@@ -179,7 +179,7 @@ public class MultilineBuildLogIndicationTest extends HudsonTestCase {
     public void testDoMatchTextUrlValidWarning() throws Exception {
         FreeStyleProject freeStyleProject = createFreeStyleProject();
         freeStyleProject.getBuildersList().add(new PrintToLogBuilder(TEST_STRING));
-        FreeStyleBuild freeStyleBuild = buildAndAssertSuccess(freeStyleProject);
+        FreeStyleBuild freeStyleBuild = freeStyleProject.scheduleBuild2(0, new Cause.UserCause()).get();
         MultilineBuildLogIndication.MultilineBuildLogIndicationDescriptor indicationDescriptor =
                 new MultilineBuildLogIndication.MultilineBuildLogIndicationDescriptor();
         String buildUrl = getURL() + freeStyleBuild.getUrl();


### PR DESCRIPTION
This fork provides some needed MultiLineBuildLogIndication
performance and bug fixes (see commit messages for more details):

**JSON Serialization**

Since inherited classes from Indication does not declare
@JsonProperty("pattern") in their constructors, the JSON
writer will use the default constructor and populate fields
using a matching (by name) getter.

This leads to one particular bad bug, where
MultiLineBuildLogIndication returns a faulty modified pattern
using the @Overidden getPattern() during JSON serialization.

**Performance fixes.**

Test data:
  Log: 49MB log @ 280.000 lines
  Multiline pattern: Simple pattern, matching +20 lines at end of log
  **Pre-fix: 32 seconds** (Note that the hardcoded timeout is 10 seconds)
  **Post-fix: 1.7 seconds**

**Multiline patterns could only match beginning of a line**