### PR TITLE
New Extension Point: IndicationFilter

### DIFF
--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/CauseManagement.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/CauseManagement.java
@@ -271,7 +271,7 @@ public class CauseManagement extends BfaGraphAction {
      * @see com.sonyericsson.jenkins.plugins.bfa.model.indication.Indication.IndicationDescriptor#getAll()
      */
     public ExtensionList<Indication.IndicationDescriptor> getIndicationDescriptors() {
-        return Indication.IndicationDescriptor.getAll();
+        return Indication.IndicationDescriptor.getFiltered();
     }
 
     /**

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/indication/Indication.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/indication/Indication.java
@@ -36,6 +36,7 @@ import org.codehaus.jackson.annotate.JsonIgnoreType;
 import org.codehaus.jackson.annotate.JsonProperty;
 import org.codehaus.jackson.annotate.JsonTypeInfo;
 import org.kohsuke.stapler.QueryParameter;
+
 import java.io.Serializable;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -116,8 +117,25 @@ public abstract class Indication implements Describable<Indication>, Serializabl
          *
          * @return the list of descriptors.
          */
-        public static ExtensionList<IndicationDescriptor> getAll() {
+        private static ExtensionList<IndicationDescriptor> getAll() {
             return Hudson.getInstance().getExtensionList(IndicationDescriptor.class);
+        }
+
+        /**
+         * Provides a filtered list of all registered descriptors of this type.
+         * Plugins implementing IndicationFilter are allowed to hide existing
+         * Indicators from selection in the Cause Management UI.
+         *
+         * @return the list of filtered descriptors.
+         */
+        public static ExtensionList<IndicationDescriptor> getFiltered() {
+            ExtensionList<IndicationDescriptor> filteredIndications = getAll();
+            for (IndicationFilter filter : IndicationFilter.all()) {
+                for (IndicationDescriptor indicationDescriptor : filter.getBlockedIndicators()) {
+                    filteredIndications.remove(indicationDescriptor);
+                }
+            }
+            return filteredIndications;
         }
 
         /**

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/indication/IndicationFilter.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/indication/IndicationFilter.java
@@ -1,0 +1,53 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2016 Axis Communications AB. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.sonyericsson.jenkins.plugins.bfa.model.indication;
+
+import hudson.ExtensionList;
+import hudson.ExtensionPoint;
+import jenkins.model.Jenkins;
+
+import java.util.List;
+
+/**
+ * Allows for blocking/filtering Indications from users. This could be used
+ * to hide the included core Indicators, when plug-in provided Indicators
+ * provide a superset (or the same) of the now hidden Indicators features.
+ */
+public abstract class IndicationFilter implements ExtensionPoint {
+    /**
+     * List of blocked indicator descriptors.
+     *
+     * @return The descriptors of the Indicators intended to be hidden from the caller
+     */
+    public abstract List<Indication.IndicationDescriptor> getBlockedIndicators();
+
+    /**
+     * Fetch all IndicationFilters.
+     *
+     * @return list of all IndicationFilters
+     */
+    public static ExtensionList<IndicationFilter> all() {
+        return Jenkins.getInstance().getExtensionList(IndicationFilter.class);
+    }
+}


### PR DESCRIPTION
IndicationFilter allows plugins to hide specific indications
from the CauseManagement UI.

Indications added before a Filter is applied will still continue
to run.

The main purpose of this ExtensionPoint is to allow plugin
contributed indications to hide core indications which supply
similiar (or just a subset) of the core indicators' functionality.

Change-Id: I0dc492cdedb1232850262e1d11db35009031d9a3