### PR TITLE
Send "unknown" to Gerrit if no bfa patterns were found

### DIFF
--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/GerritMessageProviderExtension.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/GerritMessageProviderExtension.java
@@ -98,5 +98,12 @@ public class GerritMessageProviderExtension extends GerritMessageProvider {
             .append(displayData.getLinks().getBuildUrl())
             .append(" )");
         }
+
+        if (displayData.getDownstreamFailureCauses().isEmpty() && displayData.getFoundFailureCauses().isEmpty()) {
+            message.append("Unknown (")
+                    .append(Jenkins.getInstance().getRootUrl())
+                    .append(displayData.getLinks().getBuildUrl())
+                    .append(")");
+        }
     }
 }

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/GerritMessageProviderExtension.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/GerritMessageProviderExtension.java
@@ -100,6 +100,10 @@ public class GerritMessageProviderExtension extends GerritMessageProvider {
         }
 
         if (displayData.getDownstreamFailureCauses().isEmpty() && displayData.getFoundFailureCauses().isEmpty()) {
+            if (message.length() > 0) {
+                message.append("\n\n");
+            }
+
             message.append("Unknown (")
                     .append(Jenkins.getInstance().getRootUrl())
                     .append(displayData.getLinks().getBuildUrl())

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/GerritMessageProviderExtension.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/GerritMessageProviderExtension.java
@@ -104,10 +104,11 @@ public class GerritMessageProviderExtension extends GerritMessageProvider {
                 message.append("\n\n");
             }
 
-            message.append("Unknown (")
+            message.append(PluginImpl.getInstance().getNoCausesMessage())
+                    .append(" ( ")
                     .append(Jenkins.getInstance().getRootUrl())
                     .append(displayData.getLinks().getBuildUrl())
-                    .append(")");
+                    .append(" )");
         }
     }
 }


### PR DESCRIPTION
Now BFA reports something like "No problems were identified..." if there is no matches. But in case of gerrit feedback it doesn't send anything, so, user should click on feedback and discover failed child job by himself.

I think we can easily simplify this case by providing at least failed build directly to Gerrit. How it would be in Gerrit:

![screen shot 2016-12-02 at 16 51 14](https://cloud.githubusercontent.com/assets/4785672/20885628/3712b8a4-baf2-11e6-80c1-2208fa811173.png)
