### PR TITLE
Added a FailureCauseProvider for the MQ Notifier plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,12 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>com.sonymobile.jenkins.plugins.mq</groupId>
+            <artifactId>mq-notifier</artifactId>
+            <version>1.2.1</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-project</artifactId>
             <version>1.4</version>

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/providers/FailureCauseProvider.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/providers/FailureCauseProvider.java
@@ -53,7 +53,7 @@ public class FailureCauseProvider extends MQDataProvider {
                 failureCauseJSON.put("description", foundFailureCause.getDescription());
                 failureCauseJSON.put("categories", foundFailureCause.getCategories());
                 JSONObject foundIndicationsJSON = new JSONObject();
-                for(FoundIndication ind : foundFailureCause.getIndications()) {
+                for (FoundIndication ind : foundFailureCause.getIndications()) {
                     foundIndicationsJSON.put("pattern", ind.getPattern());
                     foundIndicationsJSON.put("matchingString", ind.getMatchingString());
                 }

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/providers/FailureCauseProvider.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/providers/FailureCauseProvider.java
@@ -1,0 +1,67 @@
+/*
+ *  The MIT License
+ *
+ *  Copyright 2017 Axis Communications AB. All rights reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package com.sonyericsson.jenkins.plugins.bfa.providers;
+
+import com.sonyericsson.jenkins.plugins.bfa.model.FailureCauseBuildAction;
+import com.sonyericsson.jenkins.plugins.bfa.model.FoundFailureCause;
+import com.sonyericsson.jenkins.plugins.bfa.model.indication.FoundIndication;
+import com.sonyericsson.jenkins.plugins.bfa.model.indication.Indication;
+import hudson.Extension;
+import hudson.model.Run;
+import net.sf.json.JSONObject;
+import com.sonymobile.jenkins.plugins.mq.mqnotifier.providers.MQDataProvider;
+
+import java.util.List;
+
+/**
+ * Provides information about the failure causes for a build.
+ *
+ * @author Tomas Westling &lt;tomas.westling@axis.com&gt;
+ */
+@Extension(optional = true)
+public class FailureCauseProvider extends MQDataProvider {
+
+    @Override
+    public void provideCompletedRunData(Run run, JSONObject json) {
+        FailureCauseBuildAction action = run.getAction(FailureCauseBuildAction.class);
+        if (action != null) {
+            List<FoundFailureCause> foundFailureCauses = action.getFoundFailureCauses();
+            JSONObject failureCausesJSON = new JSONObject();
+            for (FoundFailureCause foundFailureCause : foundFailureCauses) {
+                JSONObject failureCauseJSON = new JSONObject();
+                failureCauseJSON.put("name",foundFailureCause.getName());
+                failureCauseJSON.put("description",foundFailureCause.getDescription());
+                failureCauseJSON.put("categories",foundFailureCause.getCategories());
+                JSONObject foundIndicationsJSON = new JSONObject();
+                for(FoundIndication ind : foundFailureCause.getIndications()) {
+                    foundIndicationsJSON.put("pattern", ind.getPattern());
+                    foundIndicationsJSON.put("matchingString", ind.getMatchingString());
+                }
+                failureCauseJSON.put("indications", foundIndicationsJSON);
+                failureCausesJSON.put(foundFailureCause.getId(), failureCauseJSON);
+            }
+            json.put("failurecauses", failureCausesJSON);
+        }
+    }
+}

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/providers/FailureCauseProvider.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/providers/FailureCauseProvider.java
@@ -26,7 +26,6 @@ package com.sonyericsson.jenkins.plugins.bfa.providers;
 import com.sonyericsson.jenkins.plugins.bfa.model.FailureCauseBuildAction;
 import com.sonyericsson.jenkins.plugins.bfa.model.FoundFailureCause;
 import com.sonyericsson.jenkins.plugins.bfa.model.indication.FoundIndication;
-import com.sonyericsson.jenkins.plugins.bfa.model.indication.Indication;
 import hudson.Extension;
 import hudson.model.Run;
 import net.sf.json.JSONObject;
@@ -50,9 +49,9 @@ public class FailureCauseProvider extends MQDataProvider {
             JSONObject failureCausesJSON = new JSONObject();
             for (FoundFailureCause foundFailureCause : foundFailureCauses) {
                 JSONObject failureCauseJSON = new JSONObject();
-                failureCauseJSON.put("name",foundFailureCause.getName());
-                failureCauseJSON.put("description",foundFailureCause.getDescription());
-                failureCauseJSON.put("categories",foundFailureCause.getCategories());
+                failureCauseJSON.put("name", foundFailureCause.getName());
+                failureCauseJSON.put("description", foundFailureCause.getDescription());
+                failureCauseJSON.put("categories", foundFailureCause.getCategories());
                 JSONObject foundIndicationsJSON = new JSONObject();
                 for(FoundIndication ind : foundFailureCause.getIndications()) {
                     foundIndicationsJSON.put("pattern", ind.getPattern());

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/tokens/TokenUtils.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/tokens/TokenUtils.java
@@ -37,7 +37,7 @@ import java.util.regex.Pattern;
 public final class TokenUtils {
 
     /** Utility class */
-    private TokenUtils() {}
+    private TokenUtils() { }
 
     /**
      * Wrap some text

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/BuildFailureScannerHudsonTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/BuildFailureScannerHudsonTest.java
@@ -350,7 +350,7 @@ public class BuildFailureScannerHudsonTest {
     @Test
     public void testDoNotScanIfLogSizeExceedsLimit() throws Exception {
         PluginImpl.getInstance().setMaxLogSize(1);
-        FreeStyleProject project = createProject(createHugeString(1024*1024) + BUILD_LOG);
+        FreeStyleProject project = createProject(createHugeString(1024 * 1024) + BUILD_LOG);
         configureCauseAndIndication();
         Future<FreeStyleBuild> future = project.scheduleBuild2(0, new Cause.UserIdCause());
         FreeStyleBuild build = future.get(10, TimeUnit.SECONDS);
@@ -367,7 +367,7 @@ public class BuildFailureScannerHudsonTest {
     @Test
     public void testDoScanIfLogSizeIsInLimit() throws Exception {
         PluginImpl.getInstance().setMaxLogSize(2);
-        FreeStyleProject project = createProject(createHugeString(1024*1024) + BUILD_LOG);
+        FreeStyleProject project = createProject(createHugeString(1024 * 1024) + BUILD_LOG);
         configureCauseAndIndication();
         Future<FreeStyleBuild> future = project.scheduleBuild2(0, new Cause.UserIdCause());
         FreeStyleBuild build = future.get(10, TimeUnit.SECONDS);

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/FailureCauseProviderTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/FailureCauseProviderTest.java
@@ -1,0 +1,95 @@
+/*
+ *  The MIT License
+ *
+ *  Copyright 2017 Axis Communications AB. All rights reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package com.sonyericsson.jenkins.plugins.bfa;
+
+import com.sonyericsson.jenkins.plugins.bfa.model.FailureCause;
+import com.sonyericsson.jenkins.plugins.bfa.model.FailureCauseBuildAction;
+import com.sonyericsson.jenkins.plugins.bfa.model.FoundFailureCause;
+import com.sonyericsson.jenkins.plugins.bfa.model.indication.FoundIndication;
+import com.sonyericsson.jenkins.plugins.bfa.providers.FailureCauseProvider;
+import hudson.model.Run;
+import net.sf.json.JSONObject;
+import org.junit.Test;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests the FailureCauseProvider,
+ * used to prepare build information for the MQ Notification plugin.
+ * @author Tomas Westling &lt;tomas.westling@axis.com&gt;
+ */
+public class FailureCauseProviderTest {
+
+    /**
+     * Tests that the Json structure is correct after the FailureCauseProvider has done its thing.
+     */
+    @Test
+    public void testCorrectJson() {
+        List<String> categories = new ArrayList<String>();
+        categories.add("category");
+        //Create the needed objects in order to test the FailureCauseProvider.
+        //The null values in the constructor are the ones that don't end up in the resulting
+        //Json structure, namely comment, date, modifications and indications (which is added directly
+        //as a FoundIndication in the Action.
+        FailureCause failureCause = new FailureCause(
+                "myid",
+                "myname",
+                "mydescription",
+                null,
+                null,
+                categories,
+                null,
+                null);
+        List<FoundIndication> foundIndications = new ArrayList<FoundIndication>();
+        FoundIndication foundIndication = new FoundIndication(null, "mypattern", "myfile", "mystring");
+        foundIndications.add(foundIndication);
+        FoundFailureCause foundFailureCause = new FoundFailureCause(failureCause, foundIndications);
+        List<FoundFailureCause> foundFailureCauses = new ArrayList<FoundFailureCause>();
+        foundFailureCauses.add(foundFailureCause);
+        FailureCauseBuildAction action = new FailureCauseBuildAction(foundFailureCauses);
+        Run run = mock(Run.class);
+        when(run.getAction(FailureCauseBuildAction.class)).thenReturn(action);
+        FailureCauseProvider provider = new FailureCauseProvider();
+
+        //Fill the JSON object with the data from the FailureCauseProvider
+        JSONObject json = new JSONObject();
+        provider.provideCompletedRunData(run, json);
+
+        //Check that the correct values are in place in the Json.
+        JSONObject failureCausesjson = (JSONObject)json.get("failurecauses");
+        JSONObject specificFailureCausesJson = (JSONObject)failureCausesjson.get("myid");
+        List<String> cat = (List<String>) specificFailureCausesJson.get("categories");
+        JSONObject indicationsJson = (JSONObject)specificFailureCausesJson.get("indications");
+        assertThat(specificFailureCausesJson.getString("name"), is("myname"));
+        assertThat(specificFailureCausesJson.getString("description"), is("mydescription"));
+        assertThat(cat.get(0), is("category"));
+        assertThat(indicationsJson.getString("pattern"), is("mypattern"));
+        assertThat(indicationsJson.getString("matchingString"), is("mystring"));
+    }
+}

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/FailureCauseProviderTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/FailureCauseProviderTest.java
@@ -84,7 +84,7 @@ public class FailureCauseProviderTest {
         //Check that the correct values are in place in the Json.
         JSONObject failureCausesjson = (JSONObject)json.get("failurecauses");
         JSONObject specificFailureCausesJson = (JSONObject)failureCausesjson.get("myid");
-        List<String> cat = (List<String>) specificFailureCausesJson.get("categories");
+        List<String> cat = (List<String>)specificFailureCausesJson.get("categories");
         JSONObject indicationsJson = (JSONObject)specificFailureCausesJson.get("indications");
         assertThat(specificFailureCausesJson.getString("name"), is("myname"));
         assertThat(specificFailureCausesJson.getString("description"), is("mydescription"));

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/GerritMessageProviderExtensionTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/GerritMessageProviderExtensionTest.java
@@ -24,7 +24,7 @@ import java.util.List;
  * @throws Exception if so.
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({PluginImpl.class, Jenkins.class})
+@PrepareForTest({PluginImpl.class, Jenkins.class })
 public class GerritMessageProviderExtensionTest {
     private static final String JENKINS_URL =  "http://some.jenkins.com";
     private static final String BUILD_URL = "jobs/build/123";


### PR DESCRIPTION
The MQ Notifier plugin sends messages to a Message Queue,
implementing the AMQP protocol, e.g. RabbitMQ, whenever a
build is finished.
The plugin allows for other plugins to add
information to the message. This commit adds support for
the Build Failure Analyzer to supply Failure Cause information
from the build.

The dependency to the MQ Notifier plugin is made optional.