### PR TITLE
Specify the unit for the log size maximum (MB according to the code)

### DIFF
--- a/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/PluginImpl/config.jelly
+++ b/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/PluginImpl/config.jelly
@@ -116,7 +116,7 @@
             <f:checkbox name="doNotAnalyzeAbortedJob" checked="${it.doNotAnalyzeAbortedJob}" default="false"/>
         </f:entry>
         <f:entry title="${%Max size of log file}"
-            description="${%Log file with size that exceed limit would not be scanned (in MB), 0 - disable this check}">
+            description="${%maxLogSize}">
             <f:textbox name="maxLogSize"
                        value="${it.maxLogSize}"
                        default="${it.DEFAULT_MAX_LOG_SIZE}"/>

--- a/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/PluginImpl/config.jelly
+++ b/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/PluginImpl/config.jelly
@@ -116,7 +116,7 @@
             <f:checkbox name="doNotAnalyzeAbortedJob" checked="${it.doNotAnalyzeAbortedJob}" default="false"/>
         </f:entry>
         <f:entry title="${%Max size of log file}"
-            description="${%Log file with size that exceed limit would not be scanned, 0 - disable this check}">
+            description="${%Log file with size that exceed limit would not be scanned (in MB), 0 - disable this check}">
             <f:textbox name="maxLogSize"
                        value="${it.maxLogSize}"
                        default="${it.DEFAULT_MAX_LOG_SIZE}"/>

--- a/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/PluginImpl/config.properties
+++ b/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/PluginImpl/config.properties
@@ -2,3 +2,4 @@ enableGerritTriggerDescription=This option allows BFA to forward the description
 nrOfScanThreadsDescription=Number of threads per build to use when scanning the failed builds.
 testResultParsingEnabledDescription=Treat failed test cases (as indicated by JUnit/xUnit/... publishers) as failure causes.
 testResultCategoriesDescription=A space-separated list of categories to use for failure causes representing failed test cases.
+maxLogSize=Log file with size that exceeds limit (in MB) would not be scanned, 0 - disables this check


### PR DESCRIPTION
The maximum log size is very useful must the unit being used was not clear. I've added the unit in the description of the field.