### PR TITLE
JENKINS-39284_Set_build_description_to_failure_cause

### DIFF
--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/BuildFailureScanner.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/BuildFailureScanner.java
@@ -175,6 +175,19 @@ public class BuildFailureScanner extends RunListener<Run> {
                 printDownstream(buildLog, downstreamFailureCauses);
             }
 
+            if (PluginImpl.getInstance().isEnableBuildDescription() && !foundCauseList.isEmpty()) {
+              // create a build description text from the list of failures.
+              String buildDescription = "<mark><b>";
+              if (foundCauseList.get(0).getCategories() != null) {
+                buildDescription = buildDescription.concat(foundCauseList.get(0).getCategories().get(0));
+                buildDescription = buildDescription.concat(": ");
+              }
+              buildDescription = buildDescription.concat("</b> <i>");
+              buildDescription = buildDescription.concat(foundCauseList.get(0).getDescription());
+              buildDescription = buildDescription.concat("</i></mark>");
+              build.setDescription(buildDescription);
+            }
+
             StatisticsLogger.getInstance().log(build, foundCauseListToLog);
         } catch (Exception e) {
             logger.log(Level.SEVERE, "Could not scan build " + build, e);

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/PluginImpl.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/PluginImpl.java
@@ -133,6 +133,7 @@ public class PluginImpl extends Plugin {
 
     private int nrOfScanThreads;
     private int maxLogSize;
+    private Boolean enableBuildDescription;
 
     private Boolean graphsEnabled;
 
@@ -485,6 +486,19 @@ public class PluginImpl extends Plugin {
 
 
     /**
+     * If enableBuildDescription is enabled or not. Build Descriptions will be set to a concatenated
+     * list of the failure descriptions as a convenience.
+     * @return True if enabled.
+     */
+    public boolean isEnableBuildDescription() {
+      if (enableBuildDescription == null) {
+        return false;
+      } else {
+        return enableBuildDescription;
+      }
+    }
+
+    /**
      * Checks if the build with certain result should be analyzed or not.
      *
      * @param result the result
@@ -584,6 +598,7 @@ public class PluginImpl extends Plugin {
         testResultParsingEnabled = o.getBoolean("testResultParsingEnabled");
         testResultCategories = o.getString("testResultCategories");
         maxLogSize = o.optInt("maxLogSize");
+        enableBuildDescription = o.getBoolean("enableBuildDescription");
         int scanThreads = o.getInt("nrOfScanThreads");
         int minSodWorkerThreads = o.getInt("minimumNumberOfWorkerThreads");
         int maxSodWorkerThreads = o.getInt("maximumNumberOfWorkerThreads");

--- a/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/PluginImpl/config.jelly
+++ b/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/PluginImpl/config.jelly
@@ -121,5 +121,10 @@
                        value="${it.maxLogSize}"
                        default="${it.DEFAULT_MAX_LOG_SIZE}"/>
         </f:entry>
+        <f:entry title="${%Set job description to failure description}"
+             description="${%Enabling this option will set the build's description to the failure descriptions as a convenience.}">
+            <f:checkbox name="enableBuildDescription" checked="${it.enableBuildDescription}"
+                  default="false"/>
+        </f:entry>
     </f:advanced>
 </j:jelly>


### PR DESCRIPTION
[JENKINS-39284](https://issues.jenkins-ci.org/browse/JENKINS-39284)
Add an option to the BFA configuration that, when enabled, sets the build description to the failure cause.