### PR TITLE
Add statsd logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,6 +196,11 @@
             <version>1.2</version>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>com.timgroup</groupId>
+            <artifactId>java-statsd-client</artifactId>
+            <version>3.0.1</version>
+        </dependency>
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/BuildFailureScanner.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/BuildFailureScanner.java
@@ -188,6 +188,7 @@ public class BuildFailureScanner extends RunListener<Run> {
             }
 
             StatisticsLogger.getInstance().log(build, foundCauseListToLog);
+
         } catch (Exception e) {
             logger.log(Level.SEVERE, "Could not scan build " + build, e);
         }
@@ -253,7 +254,6 @@ public class BuildFailureScanner extends RunListener<Run> {
                                  + foundCause.getCategories().get(0));
                 }
             }
-
         } else {
             buildLog.println("[BFA] No failure causes found");
         }

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FoundFailureCause.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FoundFailureCause.java
@@ -99,6 +99,17 @@ public class FoundFailureCause {
     }
 
     /**
+     * Getter for a sluggified version of the name.
+     * Used by the StatsdLoggingWork as the key to send to graphite.
+     *
+     * @return the sluggified version of the name
+     */
+    @Exported
+    public String getSlugName() {
+        return name.toLowerCase().replace(' ', '-');
+    }
+
+    /**
      * Getter for the description.
      *
      * @return the description.

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/statistics/LoggingWork/KbLoggingWork.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/statistics/LoggingWork/KbLoggingWork.java
@@ -1,0 +1,91 @@
+package com.sonyericsson.jenkins.plugins.bfa.statistics.LoggingWork;
+
+import com.sonyericsson.jenkins.plugins.bfa.PluginImpl;
+import com.sonyericsson.jenkins.plugins.bfa.db.KnowledgeBase;
+import com.sonyericsson.jenkins.plugins.bfa.model.FoundFailureCause;
+import com.sonyericsson.jenkins.plugins.bfa.statistics.FailureCauseStatistics;
+import com.sonyericsson.jenkins.plugins.bfa.statistics.Statistics;
+import com.sonyericsson.jenkins.plugins.bfa.utils.BfaUtils;
+import hudson.model.AbstractBuild;
+import hudson.model.Cause;
+import hudson.model.Node;
+import hudson.model.Result;
+import hudson.model.Run;
+
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.TimeZone;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Created by ccordenier on 08/02/2017.
+ */
+public class KbLoggingWork extends LoggingWork {
+    private static final Logger logger = Logger.getLogger(KbLoggingWork.class.getName());
+
+    /**
+     * Standard constructor.
+     *
+     * @param build the build to analyse
+     * @param causes the list of found causes
+     */
+    public KbLoggingWork(Run build, List<FoundFailureCause> causes) {
+        super(build, causes);
+    }
+
+    @Override
+    public void run() {
+        String projectName = build.getParent().getFullName();
+        int buildNumber = build.getNumber();
+        String displayName = build.getDisplayName();
+        Date startingTime = build.getTime();
+        long duration = build.getDuration();
+        List<String> triggerCauses = new LinkedList<String>();
+        for (Object o : build.getCauses()) {
+            triggerCauses.add(o.getClass().getSimpleName());
+        }
+        String nodeName = "NoNodeInformation";
+        if (build instanceof AbstractBuild) {
+            AbstractBuild abstractBuild = (AbstractBuild)build;
+            Node node = abstractBuild.getBuiltOn();
+            if (node != null) {
+                nodeName = node.getNodeName();
+            }
+        }
+        int timeZoneOffset = TimeZone.getDefault().getRawOffset();
+        String master;
+
+        String result = "Unknown";
+        final Result buildResult = build.getResult();
+        if (buildResult != null) {
+            result = buildResult.toString();
+        }
+
+        List<FailureCauseStatistics> failureCauseStatistics = new LinkedList<FailureCauseStatistics>();
+        List<String> causeIds = new LinkedList<String>();
+        for (FoundFailureCause cause : causes) {
+            FailureCauseStatistics stats = new FailureCauseStatistics(cause.getId(), cause.getIndications());
+            failureCauseStatistics.add(stats);
+            causeIds.add(cause.getId());
+        }
+
+        master = BfaUtils.getMasterName();
+        Cause.UpstreamCause uc = (Cause.UpstreamCause)build.getCause(Cause.UpstreamCause.class);
+        Statistics.UpstreamCause suc = new Statistics.UpstreamCause(uc);
+        Statistics obj = new Statistics(projectName, buildNumber, displayName, startingTime, duration,
+                triggerCauses, nodeName, master, timeZoneOffset, result, suc,
+                failureCauseStatistics);
+
+        PluginImpl p = PluginImpl.getInstance();
+        KnowledgeBase kb = p.getKnowledgeBase();
+        try {
+            kb.saveStatistics(obj);
+        } catch (Exception e) {
+            logger.log(Level.WARNING, "Couldn't save statistics: ", e);
+        }
+
+        kb.updateLastSeen(causeIds, startingTime);
+    }
+}

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/statistics/LoggingWork/LoggingWork.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/statistics/LoggingWork/LoggingWork.java
@@ -1,0 +1,32 @@
+package com.sonyericsson.jenkins.plugins.bfa.statistics.LoggingWork;
+
+import com.sonyericsson.jenkins.plugins.bfa.model.FoundFailureCause;
+import hudson.model.Run;
+
+import java.util.List;
+
+/**
+ * Created by ccordenier on 08/02/2017.
+ */
+abstract class LoggingWork implements Runnable {
+
+    protected List<FoundFailureCause> causes;
+    protected Run build;
+
+    /**
+     * Standard Constructor.
+     *
+     * @param build the build to log for.
+     * @param causes the causes to log.
+     */
+    public LoggingWork(Run build, List<FoundFailureCause> causes) {
+        this.build = build;
+        this.causes = causes;
+    }
+
+    /**
+     * Generates the statistics.
+     *
+     */
+    public abstract void run();
+}

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/statistics/LoggingWork/StatsdLoggingWork.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/statistics/LoggingWork/StatsdLoggingWork.java
@@ -1,0 +1,40 @@
+package com.sonyericsson.jenkins.plugins.bfa.statistics.LoggingWork;
+
+import com.sonyericsson.jenkins.plugins.bfa.model.FoundFailureCause;
+
+import com.timgroup.statsd.StatsDClient;
+import hudson.model.Run;
+
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Created by ccordenier on 08/02/2017.
+ */
+public class StatsdLoggingWork extends LoggingWork {
+    private static final Logger logger = Logger.getLogger(StatsdLoggingWork.class.getName());
+
+    private StatsDClient statsClient;
+
+    /**
+     * Standard constructor.
+     *
+     * @param build the build to analyse
+     * @param causes the list of found causes
+     * @param statsClient the client to use to send statistics
+     */
+    public StatsdLoggingWork(Run build, List<FoundFailureCause> causes, StatsDClient statsClient) {
+        super(build, causes);
+        this.statsClient = statsClient;
+    }
+
+    @Override
+    public void run() {
+        for (FoundFailureCause cause : causes) {
+            String key = String.format("%s.causes.%s", build.getParent().getFullName(), cause.getSlugName());
+            logger.log(Level.INFO, String.format("Sending key %s", key));
+            statsClient.incrementCounter(key);
+        }
+    }
+}

--- a/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/PluginImpl/config.jelly
+++ b/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/PluginImpl/config.jelly
@@ -78,6 +78,9 @@
                 </f:optionalBlock>
             </table>
         </f:block>
+        <f:entry title="${%Use statsd to log statistics}">
+            <f:checkbox name="statsdEnabled" checked="${it.statsdEnabled}" default="false"/>
+        </f:entry>
     </f:section>
     <f:advanced>
         <f:section title="${%Scan non-scanned builds}">
@@ -122,5 +125,25 @@
                        value="${it.maxLogSize}"
                        default="${it.DEFAULT_MAX_LOG_SIZE}"/>
         </f:entry>
+        <f:section title="${%Statsd logging}">
+            <f:entry title="${%Stastd prefix}"
+                    description="${%Statsd prefix}">
+                <f:textbox name="statsdPrefix"
+                           value="${it.statsdPrefix}"
+                           default=""/>
+            </f:entry>
+            <f:entry title="${%Stastd host}"
+                    description="${%Statsd host}">
+                <f:textbox name="statsdHost"
+                           value="${it.statsdHost}"
+                           default=""/>
+            </f:entry>
+            <f:entry title="${%Stastd port}"
+                    description="${%Statsd port}">
+                <f:textbox name="statsdPort"
+                           value="${it.statsdPort}"
+                           default=""/>
+            </f:entry>
+        </f:section>
     </f:advanced>
 </j:jelly>

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/PluginImplHudsonTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/PluginImplHudsonTest.java
@@ -267,6 +267,10 @@ public class PluginImplHudsonTest {
         form.put("threadKeepAliveTime", ScanOnDemandVariables.DEFAULT_SOD_THREADS_KEEP_ALIVE_TIME);
         form.put("waitForJobShutdownTime", ScanOnDemandVariables.DEFAULT_SOD_WAIT_FOR_JOBS_SHUTDOWN_TIMEOUT);
         form.put("corePoolNumberOfThreads", ScanOnDemandVariables.DEFAULT_SOD_COREPOOL_THREADS);
+        form.put("statsdEnabled", false);
+        form.put("statsdHost", "");
+        form.put("statsdPort", 0);
+        form.put("statsdPrefix", "");
         if (convert != null) {
             form.put("convertOldKb", convert);
         }


### PR DESCRIPTION
At @Arachnys we have been happily using BuildFailureAnalyzer (for about a year I think). We wanted to gain better insight on our failures using statistics, however the setup using MongoDB did not fit our needs.

This pull-request adds an option to send metrics to a Statsd server (where it can eg be flushed to Graphite).

We have been using our fork for several months now and are happy with it. We would love to see this upstreamed!

Let us know if there are changes to be made. As developer of this, @cedric-cordenier can chime-in too.