### PR TITLE
Add a global switch to disable report when no causes identified

### DIFF
--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/PluginImpl.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/PluginImpl.java
@@ -120,6 +120,7 @@ public class PluginImpl extends Plugin {
      */
     protected static final int MINIMUM_NR_OF_SCAN_THREADS = 1;
 
+    private Boolean noCausesEnabled;
     private String noCausesMessage;
 
     private Boolean globalEnabled;
@@ -321,6 +322,28 @@ public class PluginImpl extends Plugin {
      */
     public String getNoCausesMessage() {
         return noCausesMessage;
+    }
+
+    /**
+     * Whether to display in the build page when no causes are identified.
+     *
+     * @return true if on.
+     */
+    public boolean isNoCausesEnabled() {
+        if (noCausesEnabled == null) {
+            return true;
+        } else {
+            return noCausesEnabled;
+        }
+    }
+
+    /**
+     * Sets whether the "no indications found" message should be shown in the job page when no causes are found.
+     *
+     * @param noCausesEnabled on or off. null == on.
+     */
+    public void setNoCausesEnabled(Boolean noCausesEnabled) {
+        this.noCausesEnabled = noCausesEnabled;
     }
 
     /**
@@ -577,6 +600,7 @@ public class PluginImpl extends Plugin {
     @Override
     public void configure(StaplerRequest req, JSONObject o) throws Descriptor.FormException, IOException {
         noCausesMessage = o.getString("noCausesMessage");
+        noCausesEnabled = o.getBoolean("noCausesEnabled");
         globalEnabled = o.getBoolean("globalEnabled");
         doNotAnalyzeAbortedJob = o.optBoolean("doNotAnalyzeAbortedJob", false);
         gerritTriggerEnabled = o.getBoolean("gerritTriggerEnabled");

--- a/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/PluginImpl/config.jelly
+++ b/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/PluginImpl/config.jelly
@@ -32,6 +32,10 @@
                  description="${%Whether to display graphs or not. NOTE: The selected storage type must support this!}">
             <f:checkbox name="graphsEnabled" checked="${it.graphsEnabled}" default="true"/>
         </f:entry>
+        <f:entry title="${%Enable text when no failure causes are found}"
+                 description="${%Whether to display the no problems identified message at all}">
+            <f:checkbox name="noCausesEnabled" checked="${it.noCausesEnabled}" default="true"/>
+        </f:entry>
         <f:entry title="${%Text when no failure causes are found}"
                  description="${%If no problems are identified, this text will be shown on the build page}">
             <f:textbox name="noCausesMessage" value="${it.noCausesMessage}"/>

--- a/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/model/FailureCauseBuildAction/summary.groovy
+++ b/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/model/FailureCauseBuildAction/summary.groovy
@@ -31,20 +31,27 @@ def l = namespace(lib.LayoutTagLib)
 
 index = 1
 
-tr {
-    td {
-        img(width: "48", height: "48", src: my.getImageUrl(), style: "margin-right:1em;")
-    }
-    td(style: "vertical-align: middle;") {
-        h2(_("Identified problems"))
-    }
-}
+def rootFailureDisplayData = my.getFailureCauseDisplayData()
+if (! (rootFailureDisplayData.getFoundFailureCauses().empty
+	   && rootFailureDisplayData.getDownstreamFailureCauses().empty
+	   && !PluginImpl.getInstance().isNoCausesEnabled())) {
 
-displayData(my.getFailureCauseDisplayData(), [], 0)
+	tr {
+	    td {
+	        img(width: "48", height: "48", src: my.getImageUrl(), style: "margin-right:1em;")
+	    }
+	    td(style: "vertical-align: middle;") {
+	        h2(_("Identified problems"))
+	    }
+	}
+
+	displayData(rootFailureDisplayData, [], 0)
+}
 
 def displayData(failureCauseDisplayData, linkTree, indent) {
 
-    if (failureCauseDisplayData.getFoundFailureCauses().empty && failureCauseDisplayData.getDownstreamFailureCauses().empty) {
+    if (failureCauseDisplayData.getFoundFailureCauses().empty
+		&& failureCauseDisplayData.getDownstreamFailureCauses().empty) {
 
         if (indent > 0) {
             displayLinkTree(linkTree)

--- a/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/model/FailureCauseMatrixBuildAction/summary.groovy
+++ b/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/model/FailureCauseMatrixBuildAction/summary.groovy
@@ -33,31 +33,38 @@ def l = namespace(lib.LayoutTagLib)
 
 index = 1
 
-tr {
-    td {
-        img(width: "48", height: "48", src: my.getImageUrl(), style: "margin-right:1em;")
-    }
-    td(style: "vertical-align: middle;") {
-        h2(_("Identified problems"))
-    }
-}
+def rootFailureDisplayData = my.getFailureCauseDisplayData()
+if (! (rootFailureDisplayData.getFoundFailureCauses().empty
+	&& rootFailureDisplayData.getDownstreamFailureCauses().empty
+	&& !PluginImpl.getInstance().isNoCausesEnabled())) {
 
-my.getRunsWithAction().each { run ->
-    tr {
-        td {}
-        td(style: "font-size: larger; font-weight: bold") {
-            text(_("Matrix build "))
-            a(href: run.getParent().getCombination().toString()) {
-                text(_(run.getFullDisplayName()))
-            }
-        }
-    }
-    displayData(my.getFailureCauseDisplayData(run), run, [], 0)
+	tr {
+	    td {
+	        img(width: "48", height: "48", src: my.getImageUrl(), style: "margin-right:1em;")
+	    }
+	    td(style: "vertical-align: middle;") {
+	        h2(_("Identified problems"))
+	    }
+	}
+
+	my.getRunsWithAction().each { run ->
+	    tr {
+	        td {}
+	        td(style: "font-size: larger; font-weight: bold") {
+	            text(_("Matrix build "))
+	            a(href: run.getParent().getCombination().toString()) {
+	                text(_(run.getFullDisplayName()))
+	            }
+	        }
+	    }
+	    displayData(my.getFailureCauseDisplayData(run), run, [], 0)
+	}
 }
 
 def displayData(failureCauseDisplayData, run, linkTree, indent) {
 
-    if (failureCauseDisplayData.getFoundFailureCauses().empty && failureCauseDisplayData.getDownstreamFailureCauses().empty) {
+    if (failureCauseDisplayData.getFoundFailureCauses().empty
+		&& failureCauseDisplayData.getDownstreamFailureCauses().empty) {
 
         if (indent > 0) {
             displayLinkTree(linkTree)

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/BuildFailureScannerHudsonTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/BuildFailureScannerHudsonTest.java
@@ -325,6 +325,31 @@ public class BuildFailureScannerHudsonTest {
     }
 
     /**
+     * Tests that "no problem identified" message is not shown when no failure cause has been found.
+     *
+     * @throws Exception if so.
+     */
+    @Test
+    public void testNoIndicationMessageShownIfNoCausesDisabled() throws Exception {
+        FreeStyleProject project = createProject();
+        PluginImpl.getInstance().setNoCausesEnabled(false);
+
+        configureCauseAndIndication(new BuildLogIndication(".*something completely different.*"));
+
+        Future<FreeStyleBuild> future = project.scheduleBuild2(0, new Cause.UserIdCause());
+        FreeStyleBuild build = future.get(10, TimeUnit.SECONDS);
+        jenkins.assertBuildStatus(Result.FAILURE, build);
+        FailureCauseBuildAction action = build.getAction(FailureCauseBuildAction.class);
+        assertNotNull(action);
+        assertTrue(action.getFoundFailureCauses().isEmpty());
+
+        HtmlPage page = jenkins.createWebClient().goTo(build.getUrl());
+        HtmlElement document = page.getDocumentElement();
+        HtmlElement heading = document.getFirstByXPath("//h4[text()='No identified problem']");
+        assertNull(heading);
+    }
+
+    /**
      * Makes sure that the build action is not added to a successful build.
      *
      * @throws Exception if so.

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/PluginImplHudsonTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/PluginImplHudsonTest.java
@@ -255,6 +255,7 @@ public class PluginImplHudsonTest {
     private JSONObject createForm(String expectedNoCauseMessage, int nrOfScanThreads, Boolean convert) {
         JSONObject form = new JSONObject();
         form.put("noCausesMessage", expectedNoCauseMessage);
+        form.put("noCausesEnabled", true);
         form.put("globalEnabled", true);
         form.put("graphsEnabled", true);
         form.put("gerritTriggerEnabled", true);

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/TransientCauseManagementHudsonTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/TransientCauseManagementHudsonTest.java
@@ -34,6 +34,7 @@ import com.sonyericsson.jenkins.plugins.bfa.model.FailureCauseBuildAction;
 import hudson.model.Cause;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
+import hudson.model.Item;
 import hudson.model.Result;
 import hudson.tasks.Shell;
 import org.jvnet.hudson.test.HudsonTestCase;
@@ -64,7 +65,7 @@ public class TransientCauseManagementHudsonTest extends HudsonTestCase {
     public void testOnAProject() throws Exception {
         FreeStyleProject project = createFreeStyleProject("nils-job");
         project.getBuildersList().add(new Shell("env | sort"));
-        project = configRoundtrip(project);
+        project = (FreeStyleProject)configRoundtrip((Item)project);
         WebClient web = createWebClient();
         HtmlPage page = web.goTo("/" + project.getUrl());
         try {

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/sod/ScanOnDemandBaseActionTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/sod/ScanOnDemandBaseActionTest.java
@@ -160,7 +160,7 @@ public class ScanOnDemandBaseActionTest {
     @Test
     public void testShouldOnlyShowWhenScanningIsEnabled() throws Exception {
         FreeStyleProject project = j.createFreeStyleProject();
-        project = j.configRoundtrip(project);
+        project = (FreeStyleProject)j.configRoundtrip((Item)project);
         String expectedHref = "/jenkins/" + project.getUrl() + "scan-on-demand";
 
         JenkinsRule.WebClient client = j.createWebClient();


### PR DESCRIPTION
When a build fails and no build causes in the knowledge base are
matched against the console log, the build page reports with an
heading and a message that there was "No identified problem".

While most users would understand the message, we had reports
from the developers reporting that the message is very confusing,
in particular in the early stages after the plugin is deployed,
and the knowledge base does not include many frequent failures.

This patch introduces a global switch that lets the administrator
turn off the display of the build analyzer block on build pages
of jobs that failed and no indication was found.