### PR TITLE
[JENKINS-48932] - Whitelist extra java.util.Collection classes being used in BFA

### DIFF
--- a/src/main/resources/META-INF/hudson.remoting.ClassFilter
+++ b/src/main/resources/META-INF/hudson.remoting.ClassFilter
@@ -1,0 +1,2 @@
+java.util.Collections$SynchronizedList
+java.util.Collections$SynchronizedRandomAccessList


### PR DESCRIPTION
It is a plan C fix, which does not include PCT Compatibility (#81) and which does not wait for adding these entries on the core side (https://github.com/jenkinsci/jenkins/pull/3234).

https://issues.jenkins-ci.org/browse/JENKINS-48932

@reviewbybees @rsandell 