### PR TITLE
Display HTML for cause description in matrix

### DIFF
--- a/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/model/FailureCauseMatrixBuildAction/summary.groovy
+++ b/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/model/FailureCauseMatrixBuildAction/summary.groovy
@@ -124,7 +124,7 @@ def displayCauses(cause, run, indent, links) {
                 br {}
                 br {}
                 b(style: "font-weight: normal") {
-                    text(cause.description)
+                    raw(app.markupFormatter.translate(cause.description))
                 }
                 br {}
                 cause.getIndications().each { indication ->


### PR DESCRIPTION
FailureCauseBuildAction displays HTML properly (like bold text or paragraphs) while FailureCauseMatrixBuildAction displays plain text. So I just propose using the same formatting for cause descriptions in both templates.