### PR TITLE
Escape regex special chars in project full name

### DIFF
--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/graphs/ProjectGraphAction.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/graphs/ProjectGraphAction.java
@@ -201,7 +201,7 @@ public class ProjectGraphAction extends BfaGraphAction {
      */
     public static void invalidateProjectGraphCache(Job project) {
         Pattern projectPattern = Pattern.compile("^.*" + ID_SEPARATOR
-                + project.getFullName() + ID_SEPARATOR + ".*$");
+                + Pattern.quote(project.getFullName()) + ID_SEPARATOR + ".*$");
         GraphCache.getInstance().invalidateMatching(projectPattern);
     }
 }


### PR DESCRIPTION
Using Windows and matrices, some project names include backslashes that cause exceptions in onCompleted method. Other Regex special characters could be present so Pattern.quote avoids the whole problem!