### PR TITLE
Add support for Token Macro tm pipeline step

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>token-macro</artifactId>
-            <version>1.10</version>
+            <version>2.0</version>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>token-macro</artifactId>
-            <version>2.0</version>
+            <version>2.2</version>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/tokens/Token.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/tokens/Token.java
@@ -23,16 +23,20 @@
  */
 package com.sonyericsson.jenkins.plugins.bfa.tokens;
 
+import com.google.common.collect.ListMultimap;
 import com.sonyericsson.jenkins.plugins.bfa.model.FailureCauseBuildAction;
 import com.sonyericsson.jenkins.plugins.bfa.model.FailureCauseMatrixBuildAction;
 import com.sonyericsson.jenkins.plugins.bfa.sod.ScanOnDemandTask;
 import hudson.Extension;
+import hudson.FilePath;
 import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import hudson.model.TaskListener;
 import org.jenkinsci.plugins.tokenmacro.DataBoundTokenMacro;
 import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 
 import java.io.IOException;
+import java.util.Map;
 
 /**
  * The Build Failure Analyzer token for TokenMacro consumers.
@@ -94,15 +98,33 @@ public class Token extends DataBoundTokenMacro {
     public String evaluate(final AbstractBuild<?, ?> build, final TaskListener listener, final String macroName)
         throws MacroEvaluationException, IOException, InterruptedException {
 
-        // Scan the build now.
-        new ScanOnDemandTask(build).run();
+        return evaluate(build);
+    }
 
-        final FailureCauseBuildAction action = build.getAction(FailureCauseBuildAction.class);
+    @Override
+    public String evaluate(final Run<?, ?> run, final FilePath workspace, final TaskListener listener,
+                           final String macroName, final Map<String, String> arguments,
+                           final ListMultimap<String, String> argumentMultimap)
+            throws MacroEvaluationException, IOException, InterruptedException {
+
+        return evaluate(run);
+    }
+
+    /**
+     * @param run The run to analyze
+     * @return The results of the build failure analyzer
+     */
+    private String evaluate(final Run<?, ?> run) {
+
+        // Scan the build now.
+        new ScanOnDemandTask(run).run();
+
+        final FailureCauseBuildAction action = run.getAction(FailureCauseBuildAction.class);
         if (action != null) {
             return renderer.render(action);
         }
 
-        final FailureCauseMatrixBuildAction matrixAction = build.getAction(FailureCauseMatrixBuildAction.class);
+        final FailureCauseMatrixBuildAction matrixAction = run.getAction(FailureCauseMatrixBuildAction.class);
         if (matrixAction != null) {
             return renderer.render(matrixAction);
         }

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/tokens/Token.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/tokens/Token.java
@@ -23,7 +23,6 @@
  */
 package com.sonyericsson.jenkins.plugins.bfa.tokens;
 
-import com.google.common.collect.ListMultimap;
 import com.sonyericsson.jenkins.plugins.bfa.model.FailureCauseBuildAction;
 import com.sonyericsson.jenkins.plugins.bfa.model.FailureCauseMatrixBuildAction;
 import com.sonyericsson.jenkins.plugins.bfa.sod.ScanOnDemandTask;
@@ -36,7 +35,6 @@ import org.jenkinsci.plugins.tokenmacro.DataBoundTokenMacro;
 import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 
 import java.io.IOException;
-import java.util.Map;
 
 /**
  * The Build Failure Analyzer token for TokenMacro consumers.
@@ -103,8 +101,7 @@ public class Token extends DataBoundTokenMacro {
 
     @Override
     public String evaluate(final Run<?, ?> run, final FilePath workspace, final TaskListener listener,
-                           final String macroName, final Map<String, String> arguments,
-                           final ListMultimap<String, String> argumentMultimap)
+                           final String macroName)
             throws MacroEvaluationException, IOException, InterruptedException {
 
         return evaluate(run);

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/tokens/PipelineTokenTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/tokens/PipelineTokenTest.java
@@ -4,10 +4,8 @@ import hudson.FilePath;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
-import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import static org.junit.Assert.assertEquals;
@@ -16,33 +14,43 @@ import static org.junit.Assert.assertEquals;
  * Tests that the plugin is compatible with the token macro pipeline step.
  */
 public class PipelineTokenTest {
+    /**
+     * The Jenkins Rule.
+     */
     @Rule
+    //CS IGNORE VisibilityModifier FOR NEXT 1 LINES. REASON: Jenkins Rule
     public JenkinsRule jenkinsRule = new JenkinsRule();
 
-    @ClassRule
-    public static BuildWatcher buildWatcher = new BuildWatcher();
+    //CS IGNORE LineLength FOR NEXT 11 LINES. REASON: Test data.
+    private static final String DECLARATIVE_PIPELINE =
+                      "pipeline {\n"
+                    + "  agent any\n"
+                    + "  stages {\n"
+                    + "    stage(\"Run declarative bfa\") {\n"
+                    + "      steps {\n"
+                    + "        writeFile file: 'bfa.log', text: tm('''${BUILD_FAILURE_ANALYZER, noFailureText=\"No errors found - Declarative\"}''')\n"
+                    + "      }\n"
+                    + "    }\n"
+                    + "  }\n"
+                    + "}\n";
 
-    private static final String BUILD_SCRIPT =
-  "pipeline {\n"
-+ "    agent any\n"
-+ "    stages {\n"
-+ "        stage(\"Run bfa\") {\n"
-+ "            steps {\n"
-+ "                writeFile file: 'bfa.log', text: tm('''${BUILD_FAILURE_ANALYZER, noFailureText=\"None Found\"}''')\n"
-+ "            }\n"
-+ "        }\n"
-+ "    }\n"
-+ "}\n";
+    //CS IGNORE LineLength FOR NEXT 6 LINES. REASON: Test data.
+    private static final String SCRIPTED_PIPELINE =
+                      "node {\n"
+                    + "  stage(\"Run scripted bfa\") {\n"
+                    + "    writeFile file: 'bfa.log', text: tm('''${BUILD_FAILURE_ANALYZER, noFailureText=\"No errors found - Scripted\"}''')\n"
+                    + "  }\n"
+                    + "}\n";
 
     /**
-     * Tests that the plugin is run by the tm pipeline step and writes the result to a file.
+     * Tests that the plugin is run by the tm pipeline step in a declarative pipeline by writing the result to a file.
      *
      * @throws Exception If necessary
      */
     @Test
-    public void pipelineEcho() throws Exception {
+    public void declarativePipelineTokenMacro() throws Exception {
         WorkflowJob project = jenkinsRule.createProject(WorkflowJob.class);
-        project.setDefinition(new CpsFlowDefinition(BUILD_SCRIPT, true));
+        project.setDefinition(new CpsFlowDefinition(DECLARATIVE_PIPELINE, true));
 
         final WorkflowRun build = jenkinsRule.buildAndAssertSuccess(project);
         final FilePath workspace = jenkinsRule.jenkins.getWorkspaceFor(project);
@@ -50,6 +58,25 @@ public class PipelineTokenTest {
 
         final String bfaLogText = bfaLog.readToString();
 
-        assertEquals("None Found", bfaLogText);
+        assertEquals("No errors found - Declarative", bfaLogText);
+    }
+
+    /**
+     * Tests that the plugin is run by the tm pipeline step in a scripted pipeline by writing the result to a file.
+     *
+     * @throws Exception If necessary
+     */
+    @Test
+    public void scriptedPipelineTokenMacro() throws Exception {
+        WorkflowJob project = jenkinsRule.createProject(WorkflowJob.class);
+        project.setDefinition(new CpsFlowDefinition(SCRIPTED_PIPELINE, true));
+
+        final WorkflowRun build = jenkinsRule.buildAndAssertSuccess(project);
+        final FilePath workspace = jenkinsRule.jenkins.getWorkspaceFor(project);
+        final FilePath bfaLog = workspace.child("bfa.log");
+
+        final String bfaLogText = bfaLog.readToString();
+
+        assertEquals("No errors found - Scripted", bfaLogText);
     }
 }

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/tokens/PipelineTokenTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/tokens/PipelineTokenTest.java
@@ -1,0 +1,55 @@
+package com.sonyericsson.jenkins.plugins.bfa.tokens;
+
+import hudson.FilePath;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests that the plugin is compatible with the token macro pipeline step.
+ */
+public class PipelineTokenTest {
+    @Rule
+    public JenkinsRule jenkinsRule = new JenkinsRule();
+
+    @ClassRule
+    public static BuildWatcher buildWatcher = new BuildWatcher();
+
+    private static final String BUILD_SCRIPT =
+  "pipeline {\n"
++ "    agent any\n"
++ "    stages {\n"
++ "        stage(\"Run bfa\") {\n"
++ "            steps {\n"
++ "                writeFile file: 'bfa.log', text: tm('''${BUILD_FAILURE_ANALYZER, noFailureText=\"None Found\"}''')\n"
++ "            }\n"
++ "        }\n"
++ "    }\n"
++ "}\n";
+
+    /**
+     * Tests that the plugin is run by the tm pipeline step and writes the result to a file.
+     *
+     * @throws Exception If necessary
+     */
+    @Test
+    public void pipelineEcho() throws Exception {
+        WorkflowJob project = jenkinsRule.createProject(WorkflowJob.class);
+        project.setDefinition(new CpsFlowDefinition(BUILD_SCRIPT, true));
+
+        final WorkflowRun build = jenkinsRule.buildAndAssertSuccess(project);
+        final FilePath workspace = jenkinsRule.jenkins.getWorkspaceFor(project);
+        final FilePath bfaLog = workspace.child("bfa.log");
+
+        final String bfaLogText = bfaLog.readToString();
+
+        assertEquals("None Found", bfaLogText);
+    }
+}

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/tokens/TokenTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/tokens/TokenTest.java
@@ -23,29 +23,26 @@
  */
 package com.sonyericsson.jenkins.plugins.bfa.tokens;
 
-import java.util.List;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import com.google.common.base.Splitter;
 import com.google.common.collect.Iterables;
 import com.sonyericsson.jenkins.plugins.bfa.BuildFailureScannerHudsonTest;
 import com.sonyericsson.jenkins.plugins.bfa.PluginImpl;
 import com.sonyericsson.jenkins.plugins.bfa.model.indication.BuildLogIndication;
 import com.sonyericsson.jenkins.plugins.bfa.test.utils.PrintToLogBuilder;
-
-import org.jenkinsci.plugins.tokenmacro.TokenMacro;
-import org.junit.Test;
-import org.jvnet.hudson.test.HudsonTestCase;
-import org.jvnet.hudson.test.MockBuilder;
-
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Result;
 import hudson.model.TaskListener;
 import hudson.util.LogTaskListener;
+import org.jenkinsci.plugins.tokenmacro.TokenMacro;
+import org.junit.Test;
+import org.jvnet.hudson.test.HudsonTestCase;
+import org.jvnet.hudson.test.MockBuilder;
+
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * @author K. R. Walker &lt;krwalker@stellarscience.com&gt;
@@ -56,113 +53,282 @@ public class TokenTest extends HudsonTestCase {
 
     private final TaskListener listener = new LogTaskListener(logger, Level.INFO);
 
+    private FreeStyleProject project;
+    private FreeStyleBuild noCauseBuild;
+    private FreeStyleBuild causeBuild;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+
+        final int timeout = 10;
+        final int quietPeriod = 0;
+
+        project = createFreeStyleProject();
+        project.getBuildersList().add(new PrintToLogBuilder(ERROR));
+        project.getBuildersList().add(new MockBuilder(Result.FAILURE));
+        final Future<FreeStyleBuild> noCauseBuildFuture = project.scheduleBuild2(quietPeriod);
+
+        noCauseBuild  = noCauseBuildFuture.get(timeout, TimeUnit.SECONDS);
+
+        BuildFailureScannerHudsonTest.configureCauseAndIndication("error",
+                "There was an error.", "comment", "category",
+                new BuildLogIndication(".*ERROR.*"));
+
+        final Future<FreeStyleBuild> buildFuture = project.scheduleBuild2(quietPeriod);
+        causeBuild = buildFuture.get(timeout, TimeUnit.SECONDS);
+    }
+
     /**
      * Test that the BUILD_FAILURE_ANALYZER token gets replaced with failure cause text as configured.
      * @throws Exception if necessary
      */
     @Test
-    public void testToken() throws Exception {
-        // CS IGNORE MagicNumberCheck FOR NEXT 63 LINES. REASON: Test data.
-        final FreeStyleProject project = createFreeStyleProject();
-        project.getBuildersList().add(new PrintToLogBuilder(ERROR));
-        project.getBuildersList().add(new MockBuilder(Result.FAILURE));
-        final Future<FreeStyleBuild> noCauseBuildFuture = project.scheduleBuild2(0);
-        final FreeStyleBuild noCauseBuild = noCauseBuildFuture.get(10, TimeUnit.SECONDS);
-        final String defaultNoResult = TokenMacro.expandAll(noCauseBuild, listener, "${BUILD_FAILURE_ANALYZER}");
+    public void testExpandAllNoError() throws Exception {
+        final String defaultNoResult = TokenMacro.expandAll(noCauseBuild, listener,
+                "${BUILD_FAILURE_ANALYZER}");
         assertEquals("", defaultNoResult);
-        BuildFailureScannerHudsonTest.configureCauseAndIndication("error", "There was an error.", "comment", "category",
-            new BuildLogIndication(".*ERROR.*"));
-        final Future<FreeStyleBuild> buildFuture = project.scheduleBuild2(0);
-        final FreeStyleBuild build = buildFuture.get(10, TimeUnit.SECONDS);
-        final String defaults = TokenMacro.expandAll(build, listener, "${BUILD_FAILURE_ANALYZER}");
+    }
+
+    /**
+     * Test that the BUILD_FAILURE_ANALYZER token gets replaced with failure cause text as configured.
+     * @throws Exception if necessary
+     */
+    @Test
+    public void testExpandNoError() throws Exception {
+        final String defaultNoResult = TokenMacro.expand(noCauseBuild, noCauseBuild.getWorkspace(), listener,
+                "${BUILD_FAILURE_ANALYZER}");
+        assertEquals("", defaultNoResult);
+    }
+
+    /**
+     * Tests the expansion when there is a failure for the default setup.
+     *
+     * @throws Exception If necessary
+     */
+    @Test
+    public void testExpandAllError() throws Exception {
+        final int expectedOutputLineCount = 4;
+        final String defaults = TokenMacro.expandAll(causeBuild, listener, "${BUILD_FAILURE_ANALYZER}");
         System.out.println("Default:\n[" + defaults + "]");
         assertTrue("Default has title", defaults.contains("Identified problems:"));
         assertTrue("Default has cause", defaults.contains("There was an error."));
         assertTrue("Default has indications", defaults.contains("Indication 1"));
         assertTrue("Default is not HTML", !defaults.contains("<li>"));
-        assertEquals("", 4, Iterables.size(Splitter.on('\n').omitEmptyStrings().split(defaults)));
+        assertEquals("", expectedOutputLineCount, Iterables.size(Splitter.on('\n')
+                .omitEmptyStrings().split(defaults)));
+    }
 
-        final String plainFull = TokenMacro.expandAll(build, listener,
+    /**
+     * Tests the expansion when there is a failure for the default setup.
+     *
+     * @throws Exception If necessary
+     */
+    @Test
+    public void testExpandError() throws Exception {
+        final int expectedOutputLineCount = 4;
+        final String defaults = TokenMacro.expand(causeBuild, causeBuild.getWorkspace(), listener,
+                "${BUILD_FAILURE_ANALYZER}");
+        System.out.println("Default:\n[" + defaults + "]");
+        assertTrue("Default has title", defaults.contains("Identified problems:"));
+        assertTrue("Default has cause", defaults.contains("There was an error."));
+        assertTrue("Default has indications", defaults.contains("Indication 1"));
+        assertTrue("Default is not HTML", !defaults.contains("<li>"));
+        assertEquals("", expectedOutputLineCount, Iterables.size(Splitter.on('\n')
+                .omitEmptyStrings().split(defaults)));
+    }
+
+    /**
+     * Tests the expansion when there is a failure that includes the title and indications.
+     *
+     * @throws Exception If necessary
+     */
+    @Test
+    public void testExpandAllnErrorWithTitleAndIndications() throws Exception {
+        final int expectedOutputLineCount = 4;
+        final String plainFull = TokenMacro.expandAll(causeBuild, listener,
             "${BUILD_FAILURE_ANALYZER, includeTitle=true, includeIndications=true}");
         System.out.println("Plaintext full:\n[" + plainFull + "]");
         assertTrue("Plaintext full has title", plainFull.contains("Identified problems:"));
         assertTrue("Plaintext full has cause", plainFull.contains("There was an error."));
         assertTrue("Plaintext full has indications", plainFull.contains("Indication 1"));
         assertTrue("Plaintext full is not HTML", !plainFull.contains("<li>"));
-        assertEquals("", 4, Iterables.size(Splitter.on('\n').omitEmptyStrings().split(plainFull)));
+        assertEquals("", expectedOutputLineCount, Iterables.size(Splitter.on('\n')
+                .omitEmptyStrings().split(plainFull)));
+    }
 
-        final String plainFullWrapped = TokenMacro.expandAll(build, listener,
+    /**
+     * Tests the expansion when there is a failure that includes the title and indications.
+     *
+     * @throws Exception If necessary
+     */
+    @Test
+    public void testExpandnErrorWithTitleAndIndications() throws Exception {
+        final int expectedOutputLineCount = 4;
+        final String plainFull = TokenMacro.expand(causeBuild, causeBuild.getWorkspace(), listener,
+                "${BUILD_FAILURE_ANALYZER, includeTitle=true, includeIndications=true}");
+        System.out.println("Plaintext full:\n[" + plainFull + "]");
+        assertTrue("Plaintext full has title", plainFull.contains("Identified problems:"));
+        assertTrue("Plaintext full has cause", plainFull.contains("There was an error."));
+        assertTrue("Plaintext full has indications", plainFull.contains("Indication 1"));
+        assertTrue("Plaintext full is not HTML", !plainFull.contains("<li>"));
+        assertEquals("", expectedOutputLineCount, Iterables.size(Splitter.on('\n')
+                .omitEmptyStrings().split(plainFull)));
+    }
+
+    /**
+     * Tests the expansion when there is a failure that includes the title, indications, and wraps the width.
+     *
+     * @throws Exception If necessary
+     */
+    @Test
+    public void testExpandAllErrorWithTitleAndIndicationsAndWrap() throws Exception {
+        final int expectedOutputLineCount = 7;
+        final String plainFullWrapped = TokenMacro.expandAll(causeBuild, listener,
             "${BUILD_FAILURE_ANALYZER, includeTitle=true, includeIndications=true, wrapWidth=8}");
         System.out.println("Plaintext full wrapped:\n[" + plainFullWrapped + "]");
         assertTrue("Plaintext full wrapped has title", plainFullWrapped.contains("Identified problems:"));
         assertTrue("Plaintext full wrapped has cause", plainFullWrapped.contains("error."));
         assertTrue("Plaintext full wrapped has indications", plainFullWrapped.contains("Indication 1"));
         assertTrue("Plaintext full wrapped is not HTML", !plainFullWrapped.contains("<li>"));
-        assertEquals("", 7, Iterables.size(Splitter.on('\n').omitEmptyStrings().split(plainFullWrapped)));
+        assertEquals("", expectedOutputLineCount, Iterables.size(Splitter.on('\n')
+                .omitEmptyStrings().split(plainFullWrapped)));
+    }
 
-        final String plainMinimal = TokenMacro.expandAll(build, listener,
+    /**
+     * Tests the expansion when there is a failure that includes the title, indications, and wraps the width.
+     *
+     * @throws Exception If necessary
+     */
+    @Test
+    public void testExpandErrorWithTitleAndIndicationsAndWrap() throws Exception {
+        final int expectedOutputLineCount = 7;
+        final String plainFullWrapped = TokenMacro.expand(causeBuild, causeBuild.getWorkspace(), listener,
+                "${BUILD_FAILURE_ANALYZER, includeTitle=true, includeIndications=true, wrapWidth=8}");
+        System.out.println("Plaintext full wrapped:\n[" + plainFullWrapped + "]");
+        assertTrue("Plaintext full wrapped has title", plainFullWrapped.contains("Identified problems:"));
+        assertTrue("Plaintext full wrapped has cause", plainFullWrapped.contains("error."));
+        assertTrue("Plaintext full wrapped has indications", plainFullWrapped.contains("Indication 1"));
+        assertTrue("Plaintext full wrapped is not HTML", !plainFullWrapped.contains("<li>"));
+        assertEquals("", expectedOutputLineCount, Iterables.size(Splitter.on('\n')
+                .omitEmptyStrings().split(plainFullWrapped)));
+    }
+
+    /**
+     * Tests the expansion when there is a failure that excludes the title and indications.
+     *
+     * @throws Exception If necessary
+     */
+    @Test
+    public void testExpandAllErrorNoTitleNoIndications() throws Exception {
+        final int expectedOutputLineCount = 1;
+        final String plainMinimal = TokenMacro.expandAll(causeBuild, listener,
             "${BUILD_FAILURE_ANALYZER, includeTitle=false, includeIndications=false}");
         System.out.println("Plaintext minimal:\n[" + plainMinimal + "]");
         assertTrue("Plaintext minimal does not have title", !plainMinimal.contains("Identified problems:"));
         assertTrue("Plaintext minimal has cause", plainMinimal.contains("There was an error."));
         assertTrue("Plaintext minimal does not have indications", !plainMinimal.contains("Indication 1"));
         assertTrue("Plaintext minimal is not HTML", !plainMinimal.contains("<li>"));
-        assertEquals("", 1, Iterables.size(Splitter.on('\n').omitEmptyStrings().split(plainMinimal)));
+        assertEquals("", expectedOutputLineCount, Iterables.size(Splitter.on('\n')
+                .omitEmptyStrings().split(plainMinimal)));
+    }
 
-        final String htmlFull = TokenMacro.expandAll(build, listener,
+    /**
+     * Tests the expansion when there is a failure that excludes the title and indications.
+     *
+     * @throws Exception If necessary
+     */
+    @Test
+    public void testExpandErrorNoTitleNoIndications() throws Exception {
+        final int expectedOutputLineCount = 1;
+        final String plainMinimal = TokenMacro.expand(causeBuild, causeBuild.getWorkspace(), listener,
+                "${BUILD_FAILURE_ANALYZER, includeTitle=false, includeIndications=false}");
+        System.out.println("Plaintext minimal:\n[" + plainMinimal + "]");
+        assertTrue("Plaintext minimal does not have title", !plainMinimal.contains("Identified problems:"));
+        assertTrue("Plaintext minimal has cause", plainMinimal.contains("There was an error."));
+        assertTrue("Plaintext minimal does not have indications", !plainMinimal.contains("Indication 1"));
+        assertTrue("Plaintext minimal is not HTML", !plainMinimal.contains("<li>"));
+        assertEquals("", expectedOutputLineCount, Iterables.size(Splitter.on('\n')
+                .omitEmptyStrings().split(plainMinimal)));
+    }
+
+    /**
+     * Tests the expansion when there is a failure that uses HTML which includes the title and indications.
+     *
+     * @throws Exception If necessary
+     */
+    @Test
+    public void testExpandAllErrorHtmlWithTitleAndIndications() throws Exception {
+        final int expectedOutputLineCount = 1;
+        final String htmlFull = TokenMacro.expandAll(causeBuild, listener,
             "${BUILD_FAILURE_ANALYZER, useHtmlFormat=true, includeTitle=true, includeIndications=true}");
         System.out.println("HTML full:\n[" + htmlFull + "]");
         assertTrue("HTML full has title", htmlFull.contains("Identified problems:"));
         assertTrue("HTML full has cause", htmlFull.contains("There was an error."));
         assertTrue("HTML full has indications", htmlFull.contains("Indication 1"));
         assertTrue("HTML full is HTML", htmlFull.contains("<li>"));
-        assertEquals("", 1, Iterables.size(Splitter.on('\n').omitEmptyStrings().split(htmlFull)));
+        assertEquals("", expectedOutputLineCount, Iterables.size(Splitter.on('\n')
+                .omitEmptyStrings().split(htmlFull)));
+    }
 
-        final String htmlMinimal = TokenMacro.expandAll(build, listener,
-            "${BUILD_FAILURE_ANALYZER, useHtmlFormat=true, includeTitle=false, includeIndications=false}");
+    /**
+     * Tests the expansion when there is a failure that uses HTML which includes the title and indications.
+     *
+     * @throws Exception If necessary
+     */
+    @Test
+    public void testExpandErrorHtmlWithTitleAndIndications() throws Exception {
+        final int expectedOutputLineCount = 1;
+        final String htmlFull = TokenMacro.expand(causeBuild, causeBuild.getWorkspace(), listener,
+                "${BUILD_FAILURE_ANALYZER, useHtmlFormat=true, includeTitle=true, "
+                        + "includeIndications=true}");
+        System.out.println("HTML full:\n[" + htmlFull + "]");
+        assertTrue("HTML full has title", htmlFull.contains("Identified problems:"));
+        assertTrue("HTML full has cause", htmlFull.contains("There was an error."));
+        assertTrue("HTML full has indications", htmlFull.contains("Indication 1"));
+        assertTrue("HTML full is HTML", htmlFull.contains("<li>"));
+        assertEquals("", expectedOutputLineCount, Iterables.size(Splitter.on('\n')
+                .omitEmptyStrings().split(htmlFull)));
+    }
+
+    /**
+     * Tests the expansion when there is a failure that uses HTML which excludes the title and indications.
+     *
+     * @throws Exception If necessary
+     */
+    @Test
+    public void testExpandAllErrorHtmlWithTitleNoIndications() throws Exception {
+        final int expectedOutputLineCount = 1;
+        final String htmlMinimal = TokenMacro.expandAll(causeBuild, listener,
+            "${BUILD_FAILURE_ANALYZER, useHtmlFormat=true, includeTitle=false, "
+                    + "includeIndications=false}");
         System.out.println("HTML minimal:\n[" + htmlMinimal + "]");
         assertTrue("HTML minimal does not have title", !htmlMinimal.contains("Identified problems:"));
         assertTrue("HTML minimal has cause", htmlMinimal.contains("There was an error."));
         assertTrue("HTML minimal does not have indications", !htmlMinimal.contains("Indication 1"));
         assertTrue("HTML minimal is HTML", htmlMinimal.contains("<li>"));
-        assertEquals("", 1, Iterables.size(Splitter.on('\n').omitEmptyStrings().split(htmlMinimal)));
+        assertEquals("", expectedOutputLineCount, Iterables.size(Splitter.on('\n')
+                .omitEmptyStrings().split(htmlMinimal)));
     }
 
     /**
-     * Test that wrap() works appropriately.
-     * @throws Exception if necessary
+     * Tests the expansion when there is a failure that uses HTML which excludes the title and indications.
+     *
+     * @throws Exception If necessary
      */
     @Test
-    public void testWrap() throws Exception {
-        // CS IGNORE OperatorWrap FOR NEXT 11 LINES. REASON: Test data.
-        final String text =
-            "Lorem ipsum dolor sit amet,\n" +
-            "consectetur adipiscing elit. Nulla euismod sapien ligula,\n" +
-            "\n" +
-            "    ac euismod quam aliquet vel.\n" +
-            "    Duis quam augue, tristique in mi ac, scelerisque\n" +
-            "    euismod nibh.\n" +
-            "\n" +
-            "Nulla accumsan velit nec neque sollicitudin,\n" +
-            "eget sagittis purus vestibulum. Nunc cursus ornare sapien\n" +
-            "sit amet hendrerit. Proin non nisi sapien.";
-        // No additional wrapping.
-        final int noWrapping = 0;
-        final List<String> unwrappedLines = TokenUtils.wrap(text, noWrapping);
-        System.out.println("Unwrapped lines:");
-        for (final String line : unwrappedLines) {
-            System.out.println(line);
-        }
-        final int expectedNoWrappingLineCount = 10;
-        assertEquals(expectedNoWrappingLineCount, unwrappedLines.size());
-        final int wrapAt35 = 35;
-        final List<String> wrappedAt35 = TokenUtils.wrap(text, wrapAt35);
-        System.out.println("Wrapped at 35:");
-        for (final String line : wrappedAt35) {
-            System.out.println(line);
-        }
-        final int expectedWrapAt35LineCount = 15;
-        assertEquals(expectedWrapAt35LineCount, wrappedAt35.size());
+    public void testExpandErrorHtmlWithTitleNoIndications() throws Exception {
+        final int expectedOutputLineCount = 1;
+        final String htmlMinimal = TokenMacro.expand(causeBuild, causeBuild.getWorkspace(), listener,
+                "${BUILD_FAILURE_ANALYZER, useHtmlFormat=true, includeTitle=false, "
+                        + "includeIndications=false}");
+        System.out.println("HTML minimal:\n[" + htmlMinimal + "]");
+        assertTrue("HTML minimal does not have title", !htmlMinimal.contains("Identified problems:"));
+        assertTrue("HTML minimal has cause", htmlMinimal.contains("There was an error."));
+        assertTrue("HTML minimal does not have indications", !htmlMinimal.contains("Indication 1"));
+        assertTrue("HTML minimal is HTML", htmlMinimal.contains("<li>"));
+        assertEquals("", expectedOutputLineCount, Iterables.size(Splitter.on('\n')
+                .omitEmptyStrings().split(htmlMinimal)));
     }
 
     /**
@@ -171,14 +337,21 @@ public class TokenTest extends HudsonTestCase {
      * @throws Exception If necessary
      */
     @Test
-    public void testNoFailureWithDefaultEmptyText() throws Exception {
-        // CS IGNORE MagicNumberCheck FOR NEXT 7 LINES. REASON: Test data.
-        final FreeStyleProject project = createFreeStyleProject();
-        project.getBuildersList().add(new PrintToLogBuilder(ERROR));
-        project.getBuildersList().add(new MockBuilder(Result.FAILURE));
-        final Future<FreeStyleBuild> noCauseBuildFuture = project.scheduleBuild2(0);
-        final FreeStyleBuild noCauseBuild = noCauseBuildFuture.get(10, TimeUnit.SECONDS);
-        final String defaultNoResult = TokenMacro.expandAll(noCauseBuild, listener, "${BUILD_FAILURE_ANALYZER}");
+    public void testExpandAllNoFailureWithDefaultEmptyText() throws Exception {
+        final String defaultNoResult = TokenMacro.expandAll(noCauseBuild, listener,
+                "${BUILD_FAILURE_ANALYZER}");
+        assertEquals("", defaultNoResult);
+    }
+
+    /**
+     * Tests the expansion when there is no failure for the default setup.
+     *
+     * @throws Exception If necessary
+     */
+    @Test
+    public void testExpandNoFailureWithDefaultEmptyText() throws Exception {
+        final String defaultNoResult = TokenMacro.expand(noCauseBuild, noCauseBuild.getWorkspace(), listener,
+                "${BUILD_FAILURE_ANALYZER}");
         assertEquals("", defaultNoResult);
     }
 
@@ -188,14 +361,20 @@ public class TokenTest extends HudsonTestCase {
      * @throws Exception If necessary
      */
     @Test
-    public void testNoFailureWithEmptyText() throws Exception {
-        // CS IGNORE MagicNumberCheck FOR NEXT 8 LINES. REASON: Test data.
-        final FreeStyleProject project = createFreeStyleProject();
-        project.getBuildersList().add(new PrintToLogBuilder(ERROR));
-        project.getBuildersList().add(new MockBuilder(Result.FAILURE));
-        final Future<FreeStyleBuild> noCauseBuildFuture = project.scheduleBuild2(0);
-        final FreeStyleBuild noCauseBuild = noCauseBuildFuture.get(10, TimeUnit.SECONDS);
+    public void testExpandAllNoFailureWithEmptyText() throws Exception {
         final String defaultNoResult = TokenMacro.expandAll(noCauseBuild, listener,
+                "${BUILD_FAILURE_ANALYZER, noFailureText=\"\"}");
+        assertEquals("", defaultNoResult);
+    }
+
+    /**
+     * Tests the expansion when there is no failure with noFailureText set to the empty string.
+     *
+     * @throws Exception If necessary
+     */
+    @Test
+    public void testExpandNoFailureWithEmptyText() throws Exception {
+        final String defaultNoResult = TokenMacro.expand(noCauseBuild, noCauseBuild.getWorkspace(), listener,
                 "${BUILD_FAILURE_ANALYZER, noFailureText=\"\"}");
         assertEquals("", defaultNoResult);
     }
@@ -206,14 +385,20 @@ public class TokenTest extends HudsonTestCase {
      * @throws Exception If necessary
      */
     @Test
-    public void testNoFailureWithText() throws Exception {
-        // CS IGNORE MagicNumberCheck FOR NEXT 8 LINES. REASON: Test data.
-        final FreeStyleProject project = createFreeStyleProject();
-        project.getBuildersList().add(new PrintToLogBuilder(ERROR));
-        project.getBuildersList().add(new MockBuilder(Result.FAILURE));
-        final Future<FreeStyleBuild> noCauseBuildFuture = project.scheduleBuild2(0);
-        final FreeStyleBuild noCauseBuild = noCauseBuildFuture.get(10, TimeUnit.SECONDS);
+    public void testExpandAllNoFailureWithText() throws Exception {
         final String defaultNoResult = TokenMacro.expandAll(noCauseBuild, listener,
+                "${BUILD_FAILURE_ANALYZER, noFailureText=\"Sample text with <b>html</b>\"}");
+        assertEquals("Sample text with <b>html</b>", defaultNoResult);
+    }
+
+    /**
+     * Tests the expansion when there is no failure with noFailureText set to something.
+     *
+     * @throws Exception If necessary
+     */
+    @Test
+    public void testExpandNoFailureWithText() throws Exception {
+        final String defaultNoResult = TokenMacro.expand(noCauseBuild, noCauseBuild.getWorkspace(), listener,
                 "${BUILD_FAILURE_ANALYZER, noFailureText=\"Sample text with <b>html</b>\"}");
         assertEquals("Sample text with <b>html</b>", defaultNoResult);
     }

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/tokens/TokenUtilsTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/tokens/TokenUtilsTest.java
@@ -1,0 +1,57 @@
+package com.sonyericsson.jenkins.plugins.bfa.tokens;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+/**
+ * Tests that the plugin can wrap token macro output.
+ */
+public class TokenUtilsTest {
+    private static final String TEST_TEXT =
+            "Lorem ipsum dolor sit amet,\n"
+                    + "consectetur adipiscing elit. Nulla euismod sapien ligula,\n"
+                    + "\n"
+                    + "    ac euismod quam aliquet vel.\n"
+                    + "    Duis quam augue, tristique in mi ac, scelerisque\n"
+                    + "    euismod nibh.\n"
+                    + "\n"
+                    + "Nulla accumsan velit nec neque sollicitudin,\n"
+                    + "eget sagittis purus vestibulum. Nunc cursus ornare sapien\n"
+                    + "sit amet hendrerit. Proin non nisi sapien.";
+
+    /**
+     * Test that wrap() with no additional wrapping works appropriately.
+     *
+     * @throws Exception if necessary
+     */
+    @Test
+    public void testNoAdditionalWrap() throws Exception {
+        final int noWrapping = 0;
+        final List<String> unwrappedLines = TokenUtils.wrap(TEST_TEXT, noWrapping);
+        System.out.println("Unwrapped lines:");
+        for (final String line : unwrappedLines) {
+            System.out.println(line);
+        }
+        final int expectedNoWrappingLineCount = 10;
+        Assert.assertEquals(expectedNoWrappingLineCount, unwrappedLines.size());
+    }
+
+    /**
+     * Test that wrap() works appropriately.
+     *
+     * @throws Exception if necessary
+     */
+    @Test
+    public void testWrap() throws Exception {
+        final int wrapAt35 = 35;
+        final List<String> wrappedAt35 = TokenUtils.wrap(TEST_TEXT, wrapAt35);
+        System.out.println("Wrapped at 35:");
+        for (final String line : wrappedAt35) {
+            System.out.println(line);
+        }
+        final int expectedWrapAt35LineCount = 15;
+        Assert.assertEquals(expectedWrapAt35LineCount, wrappedAt35.size());
+    }
+}


### PR DESCRIPTION
This PR adds the functionality to call Build Failure Analyzer from a pipeline by using the Token Macro Plugin's [`tm` pipeline step](https://jenkins.io/doc/pipeline/steps/token-macro/) that was added in v2.0, for example:
```groovy
tm 'BUILD_FAILURE_ANALYZER'
```

This pipeline step is using a new overload of `evaluate` so if you try to call it with the build failure analyzer token it won't run and it will return a message like:
> BUILD_FAILURE_ANALYZER is not supported in this context


The changes in this PR implements that overload:
```groovy
echo tm('BUILD_FAILURE_ANALYZER')
```
Output:
>[Pipeline] tm
>[BFA] Found failure cause(s):
>[BFA] Backend Compilation Error from category Backend
>[BFA] Done. 0s
>[Pipeline] echo
>Identified problems:
>* Backend Compilation Error: A build failure from MSBuild
>  * Indication 1:
>    <_link to failure_>

I've had issues with calling the macro using some parameters like `useHtmlFormat=true` -- It still runs, but without html formatting. I've been looking at the code and it seems it should work and it is most likely my unfamiliarity the Java, Groovy, and [Jenkins interesting escaping/quoting](https://gist.github.com/Faheetah/e11bd0315c34ed32e681616e41279ef4). For example the command below would return the same output as above where `useHtmlFormat` is false by default:
```
echo tm('''${BUILD_FAILURE_ANALYZER, useHtmlFormat=true}''');
```