### PR TITLE
update jackson from 2.9.3/2.9.7 to 2.9.9 CVE-2019-12086

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,12 +81,12 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.9.7</version>
+                <version>2.9.9</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>2.9.3</version>
+                <version>2.9.9</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.9