### PR TITLE
update mq-notifier (optional) from 1.2.1 to 1.2.8 fix CSRF vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
         <dependency>
             <groupId>com.sonymobile.jenkins.plugins.mq</groupId>
             <artifactId>mq-notifier</artifactId>
-            <version>1.2.1</version>
+            <version>1.2.8</version>
             <optional>true</optional>
         </dependency>
         <dependency>


### PR DESCRIPTION
https://mvnrepository.com/artifact/com.sonymobile.jenkins.plugins.mq/mq-notifier?repo=jenkins-releases

https://wiki.jenkins.io/display/JENKINS/MQ+Notifier+Plugin

 CSRF vulnerability and missing permission checks in MQ Notifier Plugin
SECURITY-972

Users with Overall/Read permission were able to access MQ Notifier Plugin’s form validation URL, having it connect to an attacker-specified MQ system with attacker-specified credentials.

Additionally, this form validation URL did not require POST requests, resulting in a CSRF vulnerability.

The form validation now performs a permission check and requires POST requests to be sent