### PR TITLE
JENKINS-54840 Remove most getLogFile references

### DIFF
--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/BuildFailureScanner.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/BuildFailureScanner.java
@@ -423,7 +423,7 @@ public class BuildFailureScanner extends RunListener<Run> {
                             singleLineCauses,
                             build,
                             reader,
-                            build.getLogFile().getName()));
+                            "log"));
         } catch (IOException e) {
             buildLog.print("[BFA] Exception during parsing file: " + e);
         } finally {

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/PluginImpl.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/PluginImpl.java
@@ -518,7 +518,7 @@ public class PluginImpl extends Plugin {
      */
     public static boolean isSizeInLimit(Run build) {
         return getInstance().getMaxLogSize() == 0
-                || getInstance().getMaxLogSize() > (build.getLogFile().length() / BYTES_IN_MEGABYTE);
+                || getInstance().getMaxLogSize() > (build.getLogText().length() / BYTES_IN_MEGABYTE);
     }
 
     /**

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/BuildLogFailureReader.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/BuildLogFailureReader.java
@@ -63,7 +63,6 @@ public class BuildLogFailureReader extends FailureReader {
      */
     @Override
     public FoundIndication scan(Run build) throws IOException {
-        String currentFile = build.getLogFile().getName();
         BufferedReader reader = null;
         try {
             reader = new BufferedReader(build.getLogReader());
@@ -74,7 +73,7 @@ public class BuildLogFailureReader extends FailureReader {
             List<FoundFailureCause> foundFailureCauses = FailureReader.scanSingleLinePatterns(causes,
                                                                                               build,
                                                                                               reader,
-                                                                                              currentFile);
+                                                                                              "log");
             if (foundFailureCauses.isEmpty()) {
                 return null;
             } else {

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/MultilineBuildLogFailureReader.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/MultilineBuildLogFailureReader.java
@@ -62,11 +62,10 @@ public class MultilineBuildLogFailureReader extends FailureReader {
      */
     @Override
     public FoundIndication scan(Run build) throws IOException {
-        String currentfile = build.getLogFile().getName();
         BufferedReader reader = null;
         try {
             reader = new BufferedReader(build.getLogReader());
-            return scanMultiLineOneFile(build, reader, currentfile);
+            return scanMultiLineOneFile(build, reader, "log");
         } finally {
             if (reader != null) {
                 try {
@@ -89,12 +88,11 @@ public class MultilineBuildLogFailureReader extends FailureReader {
      */
     public FoundIndication scan(Run build, PrintStream buildLog) {
         FoundIndication foundIndication = null;
-        String currentFile = build.getLogFile().getName();
         BufferedReader reader = null;
         long start = System.currentTimeMillis();
         try {
             reader = new BufferedReader(build.getLogReader());
-            foundIndication = scanMultiLineOneFile(build, reader, currentFile);
+            foundIndication = scanMultiLineOneFile(build, reader, "log");
         } catch (IOException ioe) {
             logger.log(Level.SEVERE, "[BFA] I/O problems during indication analysis: ", ioe);
             buildLog.println("[BFA] I/O problems during indication analysis.");

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/sod/ScanOnDemandTask.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/sod/ScanOnDemandTask.java
@@ -105,23 +105,15 @@ public class ScanOnDemandTask implements Runnable {
      * @param run the non-scanned/scanned build to scan/rescan.
      */
     public void scanBuild(Run run) {
-        FileOutputStream fos = null;
-        try {
-            fos = new FileOutputStream(run.getLogFile(), true);
-            PrintStream buildLog = new PrintStream(fos, true, "UTF8");
+        try (
+                FileOutputStream fos = new FileOutputStream(run.getLogFile(), true);
+                PrintStream buildLog = new PrintStream(fos, true, "UTF8")
+        ){
             PluginImpl.getInstance().getKnowledgeBase().removeBuildfailurecause(run);
             BuildFailureScanner.scanIfNotScanned(run, buildLog);
             run.save();
         } catch (Exception e) {
             logger.log(Level.SEVERE, "Could not get the causes from the knowledge base", e);
-        } finally {
-            if (fos != null) {
-                try {
-                    fos.close();
-                } catch (IOException e) {
-                    logger.log(Level.WARNING, "Failed to close the build log file " + run.getLogFile(), e);
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
Only remaining reference is here:
https://github.com/jenkinsci/build-failure-analyzer-plugin/compare/master...timja:feature/remove-get-log-file?expand=1#diff-7435429733d482ec50045d542da50ec5R109

Not sure the best way to handle that, I wonder if BFA should have its own log for appending to and not the main pipeline log