### PR TITLE
New DownstreamBuildFinder using build-cache-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     </parent>
 
     <properties>
-        <jenkins.version>2.60.3</jenkins.version>
+        <jenkins.version>2.73.3</jenkins.version>
         <java.level>8</java.level>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <powermock.version>1.6.6</powermock.version>

--- a/pom.xml
+++ b/pom.xml
@@ -166,6 +166,12 @@
             <artifactId>commons-net</artifactId>
             <version>3.6</version>
         </dependency>
+        <dependency>
+            <groupId>com.axis.system.jenkins.plugins.downstream</groupId>
+            <artifactId>downstream-build-cache</artifactId>
+            <version>1.3</version>
+            <optional>true</optional>
+        </dependency>
 
         <dependency>
             <groupId>io.jenkins</groupId>

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/dbf/BuildCacheDBF.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/dbf/BuildCacheDBF.java
@@ -1,0 +1,23 @@
+package com.sonyericsson.jenkins.plugins.bfa.model.dbf;
+
+import com.axis.system.jenkins.plugins.downstream.cache.BuildCache;
+import hudson.Extension;
+import hudson.model.Run;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Gets downstream builds using the build-cache plugin. This should cover most scenarios.
+ *
+ * @author Stephan Pauxberger
+ */
+@Extension(optional = true)
+public class BuildCacheDBF extends DownstreamBuildFinder {
+
+    @Override
+    public List<Run<?, ?>> getDownstreamBuilds(Run build) {
+        //noinspection unchecked
+        return new ArrayList(BuildCache.getCache().getDownstreamBuilds(build));
+    }
+}

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/dbf/BuildCacheDBF.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/dbf/BuildCacheDBF.java
@@ -14,7 +14,9 @@ import java.util.List;
  */
 @Extension(optional = true)
 public class BuildCacheDBF extends DownstreamBuildFinder {
-
+    static {
+        BuildCache.getCache();
+    }
     @Override
     public List<Run<?, ?>> getDownstreamBuilds(Run build) {
         //noinspection unchecked

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/DisplayDownstreamTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/DisplayDownstreamTest.java
@@ -83,7 +83,16 @@ public class DisplayDownstreamTest {
     private static final String PROJECT_EW = "NORTH-WEST";
     private static final String PROJECT_SE = "SOUTH-EAST";
     private static final String PROJECT_SW = "SOUTH-WEST";
-    private static final String DEFAULT = Functions.isWindows() ? "echo I am %PROJECT_NAME%" : "echo I am ${PROJECT_NAME}";
+    private static final String DEFAULT;
+
+    static {
+        if (Functions.isWindows()) {
+            DEFAULT = "echo I am %PROJECT_NAME%";
+        } else {
+            DEFAULT = "echo I am ${PROJECT_NAME}";
+        }
+    }
+
     private static final String FAILED = "rapakalja";
 
     /**
@@ -348,10 +357,11 @@ public class DisplayDownstreamTest {
     private FreeStyleProject createFreestyleProjectWithShell(String name, String command)
             throws Exception {
         final FreeStyleProject project = jenkins.createFreeStyleProject(name);
-        if (Functions.isWindows())
+        if (Functions.isWindows()) {
             project.getBuildersList().add(new BatchFile(command));
-        else
+        } else {
             project.getBuildersList().add(new Shell(command));
+        }
         return project;
     }
 }


### PR DESCRIPTION
The downstream-build-cache-plugin (https://plugins.jenkins.io/downstream-build-cache) already creates a map of downstream upstream relationships.

We can make use of that cache for finding downstream dependencies, which also works for pipeline downstream dependencies (https://issues.jenkins-ci.org/browse/JENKINS-22026)