### PR TITLE
New feature: fallback causes

### DIFF
--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/BuildFailureScanner.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/BuildFailureScanner.java
@@ -204,27 +204,27 @@ public class BuildFailureScanner extends RunListener<Run> {
                 foundCauseList = foundCauseListToLog;
             }
 
-            List<String> genericCategories = PluginImpl.getInstance().getGenericCategories();
+            List<String> fallbackCategories = PluginImpl.getInstance().getFallbackCategories();
 
-            if (!genericCategories.isEmpty()) {
+            if (!fallbackCategories.isEmpty()) {
                 // move all generic cause from the list to a second list
-                List<FoundFailureCause> foundGenericCauses = new ArrayList<>();
+                List<FoundFailureCause> foundFallbackCauses = new ArrayList<>();
 
                 for (Iterator<FoundFailureCause> iterator = foundCauseList.iterator(); iterator.hasNext();) {
                     FoundFailureCause cause = iterator.next();
-                    if (!Collections.disjoint(cause.getCategories(), genericCategories)) {
+                    if (!Collections.disjoint(cause.getCategories(), fallbackCategories)) {
                         iterator.remove();
-                        foundGenericCauses.add(cause);
+                        foundFallbackCauses.add(cause);
                     }
                 }
 
-                if (!foundGenericCauses.isEmpty()) {
+                if (!foundFallbackCauses.isEmpty()) {
                     // we have at least one generic cause
                     if (!foundCauseList.isEmpty()) {
                         logToScanLog(scanLog, "Removing generic causes");
                     } else {
                         // we have ONLY generic causes
-                        foundCauseList = foundGenericCauses;
+                        foundCauseList = foundFallbackCauses;
                     }
                 }
             }

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/PluginImpl.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/PluginImpl.java
@@ -33,6 +33,7 @@ import com.sonyericsson.jenkins.plugins.bfa.sod.ScanOnDemandQueue;
 import com.sonyericsson.jenkins.plugins.bfa.sod.ScanOnDemandVariables;
 import hudson.Extension;
 import hudson.ExtensionList;
+import hudson.Util;
 import hudson.XmlFile;
 import hudson.init.InitMilestone;
 import hudson.init.Initializer;
@@ -44,10 +45,6 @@ import hudson.model.Run;
 import hudson.security.Permission;
 import hudson.security.PermissionGroup;
 import hudson.util.CopyOnWriteList;
-import java.io.File;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import javax.annotation.Nonnull;
 import jenkins.model.GlobalConfiguration;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
@@ -55,6 +52,14 @@ import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.StaplerRequest;
+
+import javax.annotation.Nonnull;
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * The main thing.
@@ -130,6 +135,9 @@ public class PluginImpl extends GlobalConfiguration {
     private boolean doNotAnalyzeAbortedJob;
 
     private Boolean gerritTriggerEnabled;
+
+    private String genericCategoriesAsString;
+    private transient List<String> genericCategories;
 
     private transient CopyOnWriteList<FailureCause> causes;
 
@@ -385,6 +393,25 @@ public class PluginImpl extends GlobalConfiguration {
     }
 
     /**
+     * Sets the categories to be considered as generic. Causes with generic categories will only be found if
+     * there are no other, non-generic causes.
+     * @param categories The space separated list of generic categories
+     */
+    @DataBoundSetter
+    public void setGenericCategoriesAsString(String categories) {
+        this.genericCategoriesAsString = categories;
+        if (categories == null) {
+            genericCategories = Collections.emptyList();
+        } else {
+            genericCategories = Arrays.asList(Util.tokenize(categories));
+        }
+    }
+
+    public String getGenericCategoriesAsString() {
+        return Util.join(getGenericCategories(), " ");
+    }
+
+    /**
      * If failed test cases should be represented as failure causes.
      *
      * @return True if enabled.
@@ -404,6 +431,21 @@ public class PluginImpl extends GlobalConfiguration {
      */
     public String getTestResultCategories() {
         return testResultCategories;
+    }
+
+    /**
+     * Get the categories that are considered generic.
+     * @return a list of generic categories, never null.
+     */
+    public List<String> getGenericCategories() {
+        if (genericCategories == null) {
+            if (genericCategoriesAsString == null) {
+                genericCategories = Collections.emptyList();
+            } else {
+                genericCategories = Arrays.asList(Util.tokenize(genericCategoriesAsString));
+            }
+        }
+        return genericCategories;
     }
 
     /**
@@ -476,7 +518,6 @@ public class PluginImpl extends GlobalConfiguration {
         }
         return nrOfScanThreads;
     }
-
 
     /**
      * The number of threads to have in the pool for each build. Used by the {@link BuildFailureScanner}.

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/PluginImpl.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/PluginImpl.java
@@ -136,8 +136,8 @@ public class PluginImpl extends GlobalConfiguration {
 
     private Boolean gerritTriggerEnabled;
 
-    private String genericCategoriesAsString;
-    private transient List<String> genericCategories;
+    private String fallbackCategoriesAsString;
+    private transient List<String> fallbackCategories;
 
     private transient CopyOnWriteList<FailureCause> causes;
 
@@ -398,17 +398,17 @@ public class PluginImpl extends GlobalConfiguration {
      * @param categories The space separated list of generic categories
      */
     @DataBoundSetter
-    public void setGenericCategoriesAsString(String categories) {
-        this.genericCategoriesAsString = categories;
+    public void setFallbackCategoriesAsString(String categories) {
+        this.fallbackCategoriesAsString = categories;
         if (categories == null) {
-            genericCategories = Collections.emptyList();
+            fallbackCategories = Collections.emptyList();
         } else {
-            genericCategories = Arrays.asList(Util.tokenize(categories));
+            fallbackCategories = Arrays.asList(Util.tokenize(categories));
         }
     }
 
-    public String getGenericCategoriesAsString() {
-        return Util.join(getGenericCategories(), " ");
+    public String getFallbackCategoriesAsString() {
+        return Util.join(getFallbackCategories(), " ");
     }
 
     /**
@@ -437,15 +437,15 @@ public class PluginImpl extends GlobalConfiguration {
      * Get the categories that are considered generic.
      * @return a list of generic categories, never null.
      */
-    public List<String> getGenericCategories() {
-        if (genericCategories == null) {
-            if (genericCategoriesAsString == null) {
-                genericCategories = Collections.emptyList();
+    public List<String> getFallbackCategories() {
+        if (fallbackCategories == null) {
+            if (fallbackCategoriesAsString == null) {
+                fallbackCategories = Collections.emptyList();
             } else {
-                genericCategories = Arrays.asList(Util.tokenize(genericCategoriesAsString));
+                fallbackCategories = Arrays.asList(Util.tokenize(fallbackCategoriesAsString));
             }
         }
-        return genericCategories;
+        return fallbackCategories;
     }
 
     /**

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCause.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCause.java
@@ -670,23 +670,7 @@ public class FailureCause implements Serializable, Action, Describable<FailureCa
          * @return the AutoCompletionCandidates.
          */
         public AutoCompletionCandidates doAutoCompleteCategories(@QueryParameter String value) {
-            List<String> categories;
-            try {
-                categories = PluginImpl.getInstance().getKnowledgeBase().getCategories();
-            } catch (Exception e) {
-                logger.log(Level.WARNING, "Could not get the categories for autocompletion", e);
-                return null;
-            }
-            AutoCompletionCandidates candidates = new AutoCompletionCandidates();
-            if (categories == null) {
-                return candidates;
-            }
-            for (String category : categories) {
-                if (category.toLowerCase().startsWith(value.toLowerCase())) {
-                    candidates.add(category);
-                }
-            }
-            return candidates;
+            return PluginImpl.getInstance().getCategoryAutoCompletionCandidates(value);
         }
     }
 }

--- a/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/PluginImpl/config.jelly
+++ b/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/PluginImpl/config.jelly
@@ -54,8 +54,8 @@
         <f:entry title="${%Concurrent scans}" description="${%nrOfScanThreadsDescription}">
             <f:number field="nrOfScanThreads" clazz="required positive-number" />
         </f:entry>
-        <f:entry title="${%Generic categories}" description="${%genericCategoriesDescription}">
-            <f:textbox field="genericCategoriesAsString" />
+        <f:entry title="${%Fallback categories}" description="${%fallbackCategoriesDescription}">
+            <f:textbox field="fallbackCategoriesAsString" />
         </f:entry>
         <f:block>
             <table>

--- a/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/PluginImpl/config.jelly
+++ b/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/PluginImpl/config.jelly
@@ -54,6 +54,9 @@
         <f:entry title="${%Concurrent scans}" description="${%nrOfScanThreadsDescription}">
             <f:number field="nrOfScanThreads" clazz="required positive-number" />
         </f:entry>
+        <f:entry title="${%Generic categories}" description="${%genericCategoriesDescription}">
+            <f:textbox field="genericCategoriesAsString" />
+        </f:entry>
         <f:block>
             <table>
                 <f:optionalBlock name="testResultParsingEnabled"

--- a/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/PluginImpl/config.jelly
+++ b/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/PluginImpl/config.jelly
@@ -54,8 +54,8 @@
         <f:entry title="${%Concurrent scans}" description="${%nrOfScanThreadsDescription}">
             <f:number field="nrOfScanThreads" clazz="required positive-number" />
         </f:entry>
-        <f:entry title="${%Fallback categories}" description="${%fallbackCategoriesDescription}">
-            <f:textbox field="fallbackCategoriesAsString" />
+        <f:entry title="${%Fallback categories}" description="${%fallbackCategoriesDescription}" >
+            <f:textbox field="fallbackCategoriesAsString" autoCompleteDelimChar=" " />
         </f:entry>
         <f:block>
             <table>

--- a/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/PluginImpl/config.properties
+++ b/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/PluginImpl/config.properties
@@ -3,3 +3,4 @@ nrOfScanThreadsDescription=Number of threads per build to use when scanning the 
 testResultParsingEnabledDescription=Treat failed test cases (as indicated by JUnit/xUnit/... publishers) as failure causes.
 testResultCategoriesDescription=A space-separated list of categories to use for failure causes representing failed test cases.
 maxLogSize=Log file with size that exceeds limit (in MB) would not be scanned, 0 - disables this check
+genericCategoriesDescription=Causes containing on of these (space separated) categories will only be applied if there are no non-generic causes found.

--- a/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/PluginImpl/config.properties
+++ b/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/PluginImpl/config.properties
@@ -3,4 +3,4 @@ nrOfScanThreadsDescription=Number of threads per build to use when scanning the 
 testResultParsingEnabledDescription=Treat failed test cases (as indicated by JUnit/xUnit/... publishers) as failure causes.
 testResultCategoriesDescription=A space-separated list of categories to use for failure causes representing failed test cases.
 maxLogSize=Log file with size that exceeds limit (in MB) would not be scanned, 0 - disables this check
-genericCategoriesDescription=Causes containing on of these (space separated) categories will only be applied if there are no non-generic causes found.
+fallbackCategoriesDescription=Causes containing on of these (space separated) categories will only be applied if there are no non-fallback causes found.

--- a/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/PluginImpl/config.properties
+++ b/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/PluginImpl/config.properties
@@ -3,4 +3,4 @@ nrOfScanThreadsDescription=Number of threads per build to use when scanning the 
 testResultParsingEnabledDescription=Treat failed test cases (as indicated by JUnit/xUnit/... publishers) as failure causes.
 testResultCategoriesDescription=A space-separated list of categories to use for failure causes representing failed test cases.
 maxLogSize=Log file with size that exceeds limit (in MB) would not be scanned, 0 - disables this check
-fallbackCategoriesDescription=Causes containing on of these (space separated) categories will only be applied if there are no non-fallback causes found.
+fallbackCategoriesDescription=Space separated list of category names that marks fallback causes. Fallback causes will only be applied if there are no non-fallback causes found.

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/BuildFailureScannerHudsonTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/BuildFailureScannerHudsonTest.java
@@ -74,6 +74,7 @@ import java.util.StringTokenizer;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -147,6 +148,54 @@ public class BuildFailureScannerHudsonTest {
 
         assertNotNull(error);
         assertEquals("Error message not found: ", BUILD_LOG_FIRST_LINE, error.getTextContent().trim());
+    }
+
+    /**
+     * Happy test that should find one generic failure indication in the build.
+     *
+     * @throws Exception if so.
+     */
+    @Test
+    public void testOnlyOneGenericIndicationFound() throws Exception {
+        PluginImpl.getInstance().setGenericCategoriesAsString("Generic");
+
+        FailureCause genericFailureCause = configureCauseAndIndication("Generic Error", "an error", "", "Generic", new BuildLogIndication(".*Generic Error.*"));
+        FailureCause specificFailureCause = configureCauseAndIndication("Specific Error", "an error", "", "Specific", new BuildLogIndication(".*Specific Error.*"));
+
+        FreeStyleProject project = createProject("Generic Error\nUnknown Error");
+
+        Future<FreeStyleBuild> future = project.scheduleBuild2(0, new Cause.UserIdCause());
+
+        FreeStyleBuild build = future.get(10, TimeUnit.SECONDS);
+        jenkins.assertBuildStatus(Result.FAILURE, build);
+
+        List<FoundFailureCause> causeListFromAction = build.getAction(FailureCauseBuildAction.class).getFoundFailureCauses();
+        assertTrue(findCauseInList(causeListFromAction, genericFailureCause));
+        assertFalse(findCauseInList(causeListFromAction, specificFailureCause));
+    }
+
+    /**
+     * Happy test that should replace the generic failure indication with the specific one.
+     *
+     * @throws Exception if so.
+     */
+    @Test
+    public void testGenericFailureCauseIsDroppedForSpecificOne() throws Exception {
+        PluginImpl.getInstance().setGenericCategoriesAsString("Generic");
+
+        FailureCause genericFailureCause = configureCauseAndIndication("Generic Error", "an error", "", "Generic", new BuildLogIndication(".*Generic Error.*"));
+        FailureCause specificFailureCause = configureCauseAndIndication("Specific Error", "an error", "", "Specific", new BuildLogIndication(".*Specific Error.*"));
+
+        FreeStyleProject project = createProject("Generic Error\nSpecific Error");
+
+        Future<FreeStyleBuild> future = project.scheduleBuild2(0, new Cause.UserIdCause());
+
+        FreeStyleBuild build = future.get(10, TimeUnit.SECONDS);
+        jenkins.assertBuildStatus(Result.FAILURE, build);
+
+        List<FoundFailureCause> causeListFromAction = build.getAction(FailureCauseBuildAction.class).getFoundFailureCauses();
+        assertFalse(findCauseInList(causeListFromAction, genericFailureCause));
+        assertTrue(findCauseInList(causeListFromAction, specificFailureCause));
     }
 
     /**

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/BuildFailureScannerHudsonTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/BuildFailureScannerHudsonTest.java
@@ -157,10 +157,14 @@ public class BuildFailureScannerHudsonTest {
      */
     @Test
     public void testOnlyOneGenericIndicationFound() throws Exception {
-        PluginImpl.getInstance().setGenericCategoriesAsString("Generic");
+        PluginImpl.getInstance().setFallbackCategoriesAsString("Generic");
 
-        FailureCause genericFailureCause = configureCauseAndIndication("Generic Error", "an error", "", "Generic", new BuildLogIndication(".*Generic Error.*"));
-        FailureCause specificFailureCause = configureCauseAndIndication("Specific Error", "an error", "", "Specific", new BuildLogIndication(".*Specific Error.*"));
+        FailureCause genericFailureCause = configureCauseAndIndication(
+                "Generic Error", "an error", "", "Generic", new BuildLogIndication(".*Generic Error.*")
+        );
+        FailureCause specificFailureCause = configureCauseAndIndication(
+                "Specific Error", "an error", "", "Specific", new BuildLogIndication(".*Specific Error.*")
+        );
 
         FreeStyleProject project = createProject("Generic Error\nUnknown Error");
 
@@ -169,7 +173,9 @@ public class BuildFailureScannerHudsonTest {
         FreeStyleBuild build = future.get(10, TimeUnit.SECONDS);
         jenkins.assertBuildStatus(Result.FAILURE, build);
 
-        List<FoundFailureCause> causeListFromAction = build.getAction(FailureCauseBuildAction.class).getFoundFailureCauses();
+        List<FoundFailureCause> causeListFromAction = build
+                .getAction(FailureCauseBuildAction.class)
+                .getFoundFailureCauses();
         assertTrue(findCauseInList(causeListFromAction, genericFailureCause));
         assertFalse(findCauseInList(causeListFromAction, specificFailureCause));
     }
@@ -181,10 +187,14 @@ public class BuildFailureScannerHudsonTest {
      */
     @Test
     public void testGenericFailureCauseIsDroppedForSpecificOne() throws Exception {
-        PluginImpl.getInstance().setGenericCategoriesAsString("Generic");
+        PluginImpl.getInstance().setFallbackCategoriesAsString("Generic");
 
-        FailureCause genericFailureCause = configureCauseAndIndication("Generic Error", "an error", "", "Generic", new BuildLogIndication(".*Generic Error.*"));
-        FailureCause specificFailureCause = configureCauseAndIndication("Specific Error", "an error", "", "Specific", new BuildLogIndication(".*Specific Error.*"));
+        FailureCause genericFailureCause = configureCauseAndIndication(
+                "Generic Error", "an error", "", "Generic", new BuildLogIndication(".*Generic Error.*")
+        );
+        FailureCause specificFailureCause = configureCauseAndIndication(
+                "Specific Error", "an error", "", "Specific", new BuildLogIndication(".*Specific Error.*")
+        );
 
         FreeStyleProject project = createProject("Generic Error\nSpecific Error");
 
@@ -193,7 +203,9 @@ public class BuildFailureScannerHudsonTest {
         FreeStyleBuild build = future.get(10, TimeUnit.SECONDS);
         jenkins.assertBuildStatus(Result.FAILURE, build);
 
-        List<FoundFailureCause> causeListFromAction = build.getAction(FailureCauseBuildAction.class).getFoundFailureCauses();
+        List<FoundFailureCause> causeListFromAction = build
+                .getAction(FailureCauseBuildAction.class)
+                .getFoundFailureCauses();
         assertFalse(findCauseInList(causeListFromAction, genericFailureCause));
         assertTrue(findCauseInList(causeListFromAction, specificFailureCause));
     }

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCauseTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCauseTest.java
@@ -103,6 +103,7 @@ public class FailureCauseTest {
     @Test
     public void testAutoCompletionHappy() throws Exception {
         mockEmptyKnowledgeBase();
+        when(pluginMock.getCategoryAutoCompletionCandidates(any())).thenCallRealMethod();
         List<String> categories = new LinkedList<String>();
         String compFail = "compilationFailure";
         String compCrashed = "computerCrashed";


### PR DESCRIPTION
Allows to designate categories as fallback. When scanning for
known causes, fallback causes are only stored if there are no non-fallback
causes present.

Use case:
- fallback cause: A maven goal failed
- specific cause: The code did not compile

Old behaviour: Both causes would be shown, leading to descriptions like
"always look for more specific causes first"

New behaviour: if a compile error is found, only that one is shown
(maven error is ignored as fallback). Otherwise, the information that
the failure was due to a maven error (along with the link!) is still
provided.