### PR TITLE
[JENKINS-47027] fix umlauts

### DIFF
--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/PluginImpl.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/PluginImpl.java
@@ -675,9 +675,10 @@ public class PluginImpl extends GlobalConfiguration {
      * @return the AutoCompletionCandidates.
      */
     public AutoCompletionCandidates getCategoryAutoCompletionCandidates(String prefix) {
+        Jenkins.getInstance().checkPermission(UPDATE_PERMISSION);
         List<String> categories;
         try {
-            categories = PluginImpl.getInstance().getKnowledgeBase().getCategories();
+            categories = getKnowledgeBase().getCategories();
         } catch (Exception e) {
             logger.log(Level.WARNING, "Could not get the categories for autocompletion", e);
             return null;

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCause.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCause.java
@@ -50,7 +50,7 @@ import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
-import org.kohsuke.stapler.verb.POST;
+import org.kohsuke.stapler.interceptor.RequirePOST;
 import org.mongojack.Id;
 import org.mongojack.ObjectId;
 
@@ -199,6 +199,31 @@ public class FailureCause implements Serializable, Action, Describable<FailureCa
             }
         }
         return FormValidation.ok();
+    }
+
+    /**
+     * Form validation for {@link #description}. Checks for not empty and not "Description..."
+     *
+     * @param value the form value.
+     * @return {@link hudson.util.FormValidation#ok()} if everything is well.
+     * @deprecated Use {@link FailureCauseDescriptor#doCheckDescription(String)} instead
+     */
+    @Deprecated
+    public FormValidation doCheckDescription(@QueryParameter final String value) {
+        return getDescriptor().doCheckDescription(value);
+    }
+
+    /**
+     * Form validation for {@link #name}. Checks for not empty, not "New...", {@link Jenkins#checkGoodName(String)} and
+     * that it is unique based on the cache of existing causes.
+     *
+     * @param value the form value.
+     * @return {@link hudson.util.FormValidation#ok()} if everything is well.
+     * @deprecated Use {@link FailureCauseDescriptor#doCheckName(String, String)} instead
+     */
+    @Deprecated
+    public FormValidation doCheckName(@QueryParameter final String value) {
+        return getDescriptor().doCheckName(value, id);
     }
 
     /**
@@ -622,7 +647,7 @@ public class FailureCause implements Serializable, Action, Describable<FailureCa
          * @param value the form value.
          * @return {@link hudson.util.FormValidation#ok()} if everything is well.
          */
-        @POST
+        @RequirePOST
         public FormValidation doCheckDescription(@QueryParameter final String value) {
             if (Util.fixEmpty(value) == null) {
                 return FormValidation.error("You should provide a description.");
@@ -642,7 +667,7 @@ public class FailureCause implements Serializable, Action, Describable<FailureCa
          * @param id The id (if changing an existing cause).
          * @return {@link hudson.util.FormValidation#ok()} if everything is well.
          */
-        @POST
+        @RequirePOST
         public FormValidation doCheckName(
                 @QueryParameter final String value,
                 @QueryParameter final String id) {

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCause.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCause.java
@@ -50,6 +50,7 @@ import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.verb.POST;
 import org.mongojack.Id;
 import org.mongojack.ObjectId;
 
@@ -168,7 +169,8 @@ public class FailureCause implements Serializable, Action, Describable<FailureCa
     }
 
     /**
-     * Validates this FailureCause. Checks for: {@link #doCheckName(String)}, {@link #doCheckDescription(String)},
+     * Validates this FailureCause. Checks for: {@link FailureCauseDescriptor#doCheckName(String, String)},
+     * {@link FailureCauseDescriptor#doCheckDescription(String)},
      * Indications.size &gt; 0. and {@link com.sonyericsson.jenkins.plugins.bfa.model.indication.Indication#validate()}.
      *
      * @param newName        the name to validate
@@ -179,11 +181,11 @@ public class FailureCause implements Serializable, Action, Describable<FailureCa
     public FormValidation validate(String newName,
                                    String newDescription,
                                    List<Indication> newIndications) {
-        FormValidation nameVal = doCheckName(newName);
+        FormValidation nameVal = getDescriptor().doCheckName(newName, id);
         if (nameVal.kind != FormValidation.Kind.OK) {
             return nameVal;
         }
-        FormValidation descriptionVal = doCheckDescription(newDescription);
+        FormValidation descriptionVal = getDescriptor().doCheckDescription(newDescription);
         if (descriptionVal.kind != FormValidation.Kind.OK) {
             return descriptionVal;
         }
@@ -195,55 +197,6 @@ public class FailureCause implements Serializable, Action, Describable<FailureCa
             if (validation.kind != FormValidation.Kind.OK) {
                 return validation;
             }
-        }
-        return FormValidation.ok();
-    }
-
-    /**
-     * Form validation for {@link #description}. Checks for not empty and not "Description..."
-     *
-     * @param value the form value.
-     * @return {@link hudson.util.FormValidation#ok()} if everything is well.
-     */
-    public FormValidation doCheckDescription(@QueryParameter final String value) {
-        if (Util.fixEmpty(value) == null) {
-            return FormValidation.error("You should provide a description.");
-        }
-        if (CauseManagement.NEW_CAUSE_DESCRIPTION.equalsIgnoreCase(value.trim())) {
-            return FormValidation.error("Bad description.");
-        }
-        return FormValidation.ok();
-    }
-
-    /**
-     * Form validation for {@link #name}. Checks for not empty, not "New...", {@link Jenkins#checkGoodName(String)} and
-     * that it is unique based on the cache of existing causes.
-     *
-     * @param value the form value.
-     * @return {@link hudson.util.FormValidation#ok()} if everything is well.
-     */
-    public FormValidation doCheckName(@QueryParameter final String value) {
-        if (Util.fixEmpty(value) == null) {
-            return FormValidation.error("You must provide a name for the failure cause!");
-        }
-        if (CauseManagement.NEW_CAUSE_NAME.equalsIgnoreCase(value)) {
-            return FormValidation.error("Reserved name!");
-        }
-        try {
-            Jenkins.checkGoodName(value);
-        } catch (Failure failure) {
-            return FormValidation.error(failure, failure.getMessage());
-        }
-        //Use the cache it's hopefully good enough
-        try {
-            for (FailureCause other : PluginImpl.getInstance().getKnowledgeBase().getCauses()) {
-                if ((id == null || !id.equals(other.getId())) && value.equals(other.getName())) {
-                    return FormValidation.error("There is another cause with that name.");
-                }
-            }
-
-        } catch (Exception e) {
-            logger.log(Level.SEVERE, "Failed to get causes list to evaluate name! ", e);
         }
         return FormValidation.ok();
     }
@@ -661,6 +614,61 @@ public class FailureCause implements Serializable, Action, Describable<FailureCa
         @Override
         public String getDisplayName() {
             return "";
+        }
+
+        /**
+         * Form validation for {@link #description}. Checks for not empty and not "Description..."
+         *
+         * @param value the form value.
+         * @return {@link hudson.util.FormValidation#ok()} if everything is well.
+         */
+        @POST
+        public FormValidation doCheckDescription(@QueryParameter final String value) {
+            if (Util.fixEmpty(value) == null) {
+                return FormValidation.error("You should provide a description.");
+            }
+            if (CauseManagement.NEW_CAUSE_DESCRIPTION.equalsIgnoreCase(value.trim())) {
+                return FormValidation.error("Bad description.");
+            }
+            return FormValidation.ok();
+        }
+
+        /**
+         * Form validation for {@link #name}. Checks for not empty, not "New...",
+         * {@link Jenkins#checkGoodName(String)} and
+         * that it is unique based on the cache of existing causes.
+         *
+         * @param value the form value.
+         * @param id The id (if changing an existing cause).
+         * @return {@link hudson.util.FormValidation#ok()} if everything is well.
+         */
+        @POST
+        public FormValidation doCheckName(
+                @QueryParameter final String value,
+                @QueryParameter final String id) {
+            if (Util.fixEmpty(value) == null) {
+                return FormValidation.error("You must provide a name for the failure cause!");
+            }
+            if (CauseManagement.NEW_CAUSE_NAME.equalsIgnoreCase(value)) {
+                return FormValidation.error("Reserved name!");
+            }
+            try {
+                Jenkins.checkGoodName(value);
+            } catch (Failure failure) {
+                return FormValidation.error(failure, failure.getMessage());
+            }
+            //Use the cache it's hopefully good enough
+            try {
+                for (FailureCause other : PluginImpl.getInstance().getKnowledgeBase().getCauses()) {
+                    if ((id == null || !id.equals(other.getId())) && value.equals(other.getName())) {
+                        return FormValidation.error("There is another cause with that name.");
+                    }
+                }
+
+            } catch (Exception e) {
+                logger.log(Level.SEVERE, "Failed to get causes list to evaluate name! ", e);
+            }
+            return FormValidation.ok();
         }
 
         /**

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCause.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCause.java
@@ -649,6 +649,7 @@ public class FailureCause implements Serializable, Action, Describable<FailureCa
          */
         @RequirePOST
         public FormValidation doCheckDescription(@QueryParameter final String value) {
+            Jenkins.getInstance().checkPermission(PluginImpl.UPDATE_PERMISSION);
             if (Util.fixEmpty(value) == null) {
                 return FormValidation.error("You should provide a description.");
             }
@@ -671,6 +672,7 @@ public class FailureCause implements Serializable, Action, Describable<FailureCa
         public FormValidation doCheckName(
                 @QueryParameter final String value,
                 @QueryParameter final String id) {
+            Jenkins.getInstance().checkPermission(PluginImpl.UPDATE_PERMISSION);
             if (Util.fixEmpty(value) == null) {
                 return FormValidation.error("You must provide a name for the failure cause!");
             }

--- a/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/model/FailureCause/index.groovy
+++ b/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/model/FailureCause/index.groovy
@@ -64,10 +64,10 @@ l.layout(permission: PluginImpl.UPDATE_PERMISSION) {
               f.textbox(field: "id", value: my.getId())
             }
             f.entry(title: _("Name"), field: "name") {
-              f.textbox(value: my.getName(), checkUrl: "'checkName?value='+escape(this.value)")
+              f.textbox(value: my.getName(), checkMethod: "post")
             }
             f.entry(title: _("Description"), field: "description") {
-              f.textarea(value: my.getDescription(), checkUrl: "'checkDescription?value='+escape(this.value)")
+              f.textarea(value: my.getDescription(), checkMethod: "post")
             }
             f.entry(title: _("Comment"), field: "comment") {
               f.textarea(value: my.getComment())


### PR DESCRIPTION
This fixes the 'umlauts' problem (https://issues.jenkins-ci.org/browse/JENKINS-47027) which seem to be a result of wrong encoding of umlauts in +`encode()`.

By using POST instead of GET (and switching to default Descriptor based validation), we circumvent that problem.

- I moved the validation methods into the Descriptor (default behaviour)
- change the validation to POST
- Changed `FailureCauseHudsonTest` from legacy `HudsonTestCase` to using the newer `JenkinsRule` (I needed access to the WebResponseListener)