### PR TITLE
[JENKINS-59610 JENKINS-59593] Fixed configuration issues introduced in 1.23

### DIFF
--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/BuildFailureScanner.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/BuildFailureScanner.java
@@ -167,7 +167,7 @@ public class BuildFailureScanner extends RunListener<Run> {
                     if (build instanceof AbstractBuild) {
                         ComputerGraphAction.invalidateNodeGraphCache(((AbstractBuild)build).getBuiltOn());
                     }
-                } else if (PluginImpl.getInstance().getKnowledgeBase().isSuccessfulLoggingEnabled()) {
+                } else if (PluginImpl.getInstance().getKnowledgeBase().isSuccessfulLogging()) {
                     final List<FoundFailureCause> emptyCauseList
                         = Collections.synchronizedList(new LinkedList<FoundFailureCause>());
                     StatisticsLogger.getInstance().log(build, emptyCauseList);

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/PluginImpl.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/PluginImpl.java
@@ -649,21 +649,33 @@ public class PluginImpl extends GlobalConfiguration {
 
     @Override
     public boolean configure(StaplerRequest req, JSONObject o) {
-        KnowledgeBase existingKb = this.knowledgeBase;
+        KnowledgeBase existingKb = knowledgeBase;
         req.bindJSON(this, o);
 
-        if (existingKb != null && !existingKb.equals(knowledgeBase)) {
+        if (knowledgeBase != null && !existingKb.equals(knowledgeBase)) {
+            try {
+                knowledgeBase.start();
+            } catch (Exception e) {
+                logger.log(Level.SEVERE, "Could not start new knowledge base, reverting ", e);
+                // since the knowledgebase is already overwritten via req.bindJSON, we need to
+                // restore the old if the new one can't be started
+                knowledgeBase = existingKb;
+                save();
+                return true;
+            }
             if (o.getBoolean("convertOldKb")) {
                 try {
-                    knowledgeBase.start();
                     knowledgeBase.convertFrom(existingKb);
                 } catch (Exception e) {
                     logger.log(Level.SEVERE, "Could not convert knowledge base ", e);
                 }
-                knowledgeBase.stop();
             }
+            existingKb.stop();
+        } else {
+            // Since we now overwrite the existing knowledgebase immediately, we need to put it
+            // back if it was equal to the old one, or if the new one is null.
+            knowledgeBase = existingKb;
         }
-
         save();
         return true;
     }

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/PluginImpl.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/PluginImpl.java
@@ -354,7 +354,7 @@ public class PluginImpl extends GlobalConfiguration {
         if (graphsEnabled == null || knowledgeBase == null) {
             return false;
         } else {
-            return knowledgeBase.isStatisticsEnabled() && graphsEnabled;
+            return knowledgeBase.isEnableStatistics() && graphsEnabled;
         }
     }
 

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/db/KnowledgeBase.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/db/KnowledgeBase.java
@@ -178,15 +178,15 @@ public abstract class KnowledgeBase implements Describable<KnowledgeBase>, Seria
      *
      * @return true if so. False if not or not implemented.
      */
-    public abstract boolean isStatisticsEnabled();
+    public abstract boolean isEnableStatistics();
 
     /**
      * If all builds should be added to statistics logging, not just unsuccessful builds.
-     * Only relevant if {@link #isStatisticsEnabled()} is true.
+     * Only relevant if {@link #isEnableStatistics()} is true.
      *
      * @return true if set, false otherwise or if not implemented
      */
-    public abstract boolean isSuccessfulLoggingEnabled();
+    public abstract boolean isSuccessfulLogging();
 
     /**
      * Saves the Statistics.

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/db/LocalFileKnowledgeBase.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/db/LocalFileKnowledgeBase.java
@@ -207,13 +207,13 @@ public class LocalFileKnowledgeBase extends KnowledgeBase {
     }
 
     @Override
-    public boolean isStatisticsEnabled() {
+    public boolean isEnableStatistics() {
         //Not implemented
         return false;
     }
 
     @Override
-    public boolean isSuccessfulLoggingEnabled() {
+    public boolean isSuccessfulLogging() {
         //not implemented
         return false;
     }

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/db/MongoDBKnowledgeBase.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/db/MongoDBKnowledgeBase.java
@@ -451,12 +451,12 @@ public class MongoDBKnowledgeBase extends KnowledgeBase {
     }
 
     @Override
-    public boolean isStatisticsEnabled() {
+    public boolean isEnableStatistics() {
         return enableStatistics;
     }
 
     @Override
-    public boolean isSuccessfulLoggingEnabled() {
+    public boolean isSuccessfulLogging() {
         return successfulLogging;
     }
 

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/statistics/StatisticsLogger.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/statistics/StatisticsLogger.java
@@ -90,7 +90,7 @@ public final class StatisticsLogger {
      * @param causes the list of causes.
      */
     public void log(Run build, List<FoundFailureCause> causes) {
-        if (PluginImpl.getInstance().getKnowledgeBase().isStatisticsEnabled()) {
+        if (PluginImpl.getInstance().getKnowledgeBase().isEnableStatistics()) {
             queueExecutor.submit(new LoggingWork(build, causes));
         }
     }

--- a/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/CauseManagement/index.groovy
+++ b/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/CauseManagement/index.groovy
@@ -115,7 +115,7 @@ l.layout(permission: PluginImpl.VIEW_PERMISSION, norefresh: true) {
         th{text(_("Description"))}
         th{text(_("Comment"))}
         th{text(_("Modified"))}
-        if (PluginImpl.getInstance().getKnowledgeBase().isStatisticsEnabled()) {
+        if (PluginImpl.getInstance().getKnowledgeBase().isEnableStatistics()) {
             th{text(_("Last seen"))}
         }
         th{text(" ")}
@@ -151,7 +151,7 @@ l.layout(permission: PluginImpl.VIEW_PERMISSION, norefresh: true) {
               text(_("ModifiedBy", lastModifiedString, user))
             }
           }
-          if (PluginImpl.getInstance().getKnowledgeBase().isStatisticsEnabled()) {
+          if (PluginImpl.getInstance().getKnowledgeBase().isEnableStatistics()) {
             def lastOccurred = cause.getAndInitiateLastOccurred();
             def lastOccurredString = DateFormat.getDateTimeInstance(
                   DateFormat.SHORT, DateFormat.SHORT).format(lastOccurred)

--- a/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/db/MongoDBKnowledgeBase/config.jelly
+++ b/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/db/MongoDBKnowledgeBase/config.jelly
@@ -39,10 +39,10 @@
         <f:password field="password" />
     </f:entry>
     <f:entry title="${%Enable statistics logging}">
-        <f:checkbox field="enableStatistics" default="true" />
+        <f:checkbox field="enableStatistics" default="true"/>
     </f:entry>
     <f:entry title="${%Enable statistics logging of successful builds}">
-        <f:checkbox field="successfulLogging" default="false" />
+        <f:checkbox field="successfulLogging" default="false"/>
     </f:entry>
     <f:validateButton title="Test Connection" progress="Testing..." method="testConnection" with="host,port,dbName,userName,password"/>
 </j:jelly>

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/BuildFailureScannerHudsonTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/BuildFailureScannerHudsonTest.java
@@ -507,9 +507,9 @@ public class BuildFailureScannerHudsonTest {
         List<FailureCause> causes = new LinkedList<FailureCause>();
         causes.add(cause);
         KnowledgeBase base = mock(KnowledgeBase.class);
-        when(base.isStatisticsEnabled()).thenReturn(true);
+        when(base.isEnableStatistics()).thenReturn(true);
         when(base.getCauses()).thenReturn(causes);
-        when(base.isStatisticsEnabled()).thenReturn(true);
+        when(base.isEnableStatistics()).thenReturn(true);
         doAnswer(new Answer() {
             @Override
             public Object answer(InvocationOnMock invocation) throws Throwable {

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/CauseManagementHudsonTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/CauseManagementHudsonTest.java
@@ -97,9 +97,9 @@ public class CauseManagementHudsonTest extends HudsonTestCase {
     public void testTableViewNavigation() throws Exception {
         KnowledgeBase kb = PluginImpl.getInstance().getKnowledgeBase();
 
-        //Overriding isStatisticsEnabled in order to display all fields on the management page:
+        //Overriding isEnableStatistics in order to display all fields on the management page:
         KnowledgeBase mockKb = spy(kb);
-        when(mockKb.isStatisticsEnabled()).thenReturn(true);
+        when(mockKb.isEnableStatistics()).thenReturn(true);
         Whitebox.setInternalState(PluginImpl.getInstance(), "knowledgeBase", mockKb);
 
         List<String> myCategories = new LinkedList<String>();

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/jcasc/ConfigurationAsCodeMongoTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/jcasc/ConfigurationAsCodeMongoTest.java
@@ -45,10 +45,10 @@ public class ConfigurationAsCodeMongoTest {
         MongoDBKnowledgeBase knowledgeBase = (MongoDBKnowledgeBase)plugin.getKnowledgeBase();
         assertThat(knowledgeBase.getHost(), is("localhost"));
         assertThat(knowledgeBase.getDbName(), is("bfa"));
-        assertThat(knowledgeBase.isStatisticsEnabled(), is(true));
+        assertThat(knowledgeBase.isEnableStatistics(), is(true));
         assertThat(knowledgeBase.getUserName(), is("bfa"));
         assertThat(knowledgeBase.getPassword().getPlainText(), is("changeme"));
-        assertThat(knowledgeBase.isSuccessfulLoggingEnabled(), is(false));
+        assertThat(knowledgeBase.isSuccessfulLogging(), is(false));
 
         assertThat(plugin.getNoCausesMessage(), is(ConfigurationAsCodeLocalTest.NO_CAUSES_MESSAGE));
 


### PR DESCRIPTION
Since 1.23, the saving of the BFA configuration is broken.
The KnowledgeBase is always overwritten.
In a LocalKnowledgeBase, this causes all causes to be removed.
In a MongoDBKnowledgeBase:
The getters for enabling statistics and successfullogging stats
were wrongly named, causing the databinding to be broken.

JENKINS-59610
JENKINS-59593