### PR TITLE
Bump jackson2 to 2.10.0 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,12 +15,13 @@
     </parent>
 
     <properties>
-        <jenkins.version>2.73.3</jenkins.version>
+        <jenkins.version>2.138.4</jenkins.version>
         <java.level>8</java.level>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <powermock.version>1.6.6</powermock.version>
         <checkstyle.version>3.1.0</checkstyle.version>
         <configuration-as-code.version>1.20</configuration-as-code.version>
+        <jackson.version>2.10.0</jackson.version>
     </properties>
 
     <licenses>
@@ -81,12 +82,12 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.9.9</version>
+                <version>${jackson.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>2.9.9</version>
+                <version>${jackson.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -149,7 +150,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>jackson2-api</artifactId>
-            <version>2.9.9</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/PluginImplHudsonTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/PluginImplHudsonTest.java
@@ -199,6 +199,8 @@ public class PluginImplHudsonTest {
         assertSame(cause, knowledgeBase.getCauses().iterator().next());
     }
 
+    //CS IGNORE MagicNumber FOR NEXT 17 LINES. REASON: Random test data
+
     /**
      * Tests {@link PluginImpl#configure(org.kohsuke.stapler.StaplerRequest, net.sf.json.JSONObject)}.
      * Tests that a MongoDBKnowledgebase is preserved through a reconfigure without changes.


### PR DESCRIPTION
To fix security warning that GitHub irritatingly shows me all the time.
The new version of jackson-api plugin requires a new Jenkins core for unknown reason.

Also fixes a checkstyle error introduced in #112