### PR TITLE
Fix boolean options in plugin global config

### DIFF
--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/PluginImpl.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/PluginImpl.java
@@ -360,10 +360,12 @@ public class PluginImpl extends GlobalConfiguration {
 
     /**
      * Sets if graphs are enabled.
+     * Default value is false.
+     *
      * @param graphsEnabled the graph flag
      */
     @DataBoundSetter
-    public void setGraphsEnabled(Boolean graphsEnabled) {
+    public void setGraphsEnabled(boolean graphsEnabled) {
         this.graphsEnabled = graphsEnabled;
     }
 
@@ -461,19 +463,21 @@ public class PluginImpl extends GlobalConfiguration {
 
     /**
      * Sets if this feature is enabled or not. When on all unsuccessful builds will be scanned. None when off.
+     * Default value is true.
      *
-     * @param globalEnabled on or off. null == on.
+     * @param globalEnabled on or off.
      */
-    public void setGlobalEnabled(Boolean globalEnabled) {
+    public void setGlobalEnabled(boolean globalEnabled) {
         this.globalEnabled = globalEnabled;
     }
 
     /**
      * Sets if failed test cases should be represented as failure causes or not.
+     * Default value is false.
      *
-     * @param testResultParsingEnabled on or off. null == off.
+     * @param testResultParsingEnabled on or off.
      */
-    public void setTestResultParsingEnabled(Boolean testResultParsingEnabled) {
+    public void setTestResultParsingEnabled(boolean testResultParsingEnabled) {
         this.testResultParsingEnabled = testResultParsingEnabled;
     }
 
@@ -501,10 +505,11 @@ public class PluginImpl extends GlobalConfiguration {
 
     /**
      * Sets if this feature is enabled or not. When on, cause descriptions will be forwarded to Gerrit-Trigger-Plugin.
+     * Default value is true.
      *
-     * @param gerritTriggerEnabled on or off. null == on.
+     * @param gerritTriggerEnabled on or off.
      */
-    public void setGerritTriggerEnabled(Boolean gerritTriggerEnabled) {
+    public void setGerritTriggerEnabled(boolean gerritTriggerEnabled) {
         this.gerritTriggerEnabled = gerritTriggerEnabled;
     }
 


### PR DESCRIPTION
In the plugin global configuration, several boolean options (checkboxes) are not working: when you change their value via the GUI, save, and reload the configuration page, their state is actually not changed.

A good way to test them all is the following:
 - tick all checkboxes, save, reload, see some checkbox are still unticked
 - untick all checkboxes, save, reload, see some checkbox are still ticked

The only boolean option which works is `doNotAnalyzeAbortedJob`.  The four other ones (`graphsEnabled`, `globalEnabled`, `testResultParsingEnabled`, `gerritTriggerEnabled`) are broken.

I think this bug has been introduced by recent JCASC changes, more precisely by the adoption of `StaplerRequest#bindJSON(Object,JSONObject)` to replace the many explicit `something = o.getBoolean("something")` affectations in the implementation of `PluginImpl#configure(StaplerRequest,JSONObject)`.

Anyway, in this PR are two commits:
 - first, a test case which fails. Note that it's a bit clunky, because it has to use the actual `StaplerRequest` implementation instead of a mock (the purpose of the test being to check that `configure`, thus basically `StaplerRequest#bindJSON`, works as expected on these options). 
 - then a fix for `PluginImpl`: it changes four `setSomething(Boolean)` methods into `setSomething(boolean)`. It happens to be enough to make `bindJSON` work. Maybe it's not the only way, I don't know, but it seemed simple enough. It's a slight API change, but really, I can't think of a legitimate case for calling these setters with anything but actual boolean values (why would anything call them with `null` for instance?).