### PR TITLE
stop the MongoDB processes forked in tests

### DIFF
--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/db/EmbeddedMongoTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/db/EmbeddedMongoTest.java
@@ -25,6 +25,7 @@ package com.sonyericsson.jenkins.plugins.bfa.db;
 
 import de.flapdoodle.embed.mongo.Command;
 import de.flapdoodle.embed.mongo.MongodExecutable;
+import de.flapdoodle.embed.mongo.MongodProcess;
 import de.flapdoodle.embed.mongo.MongodStarter;
 import de.flapdoodle.embed.mongo.config.ArtifactStoreBuilder;
 import de.flapdoodle.embed.mongo.config.DownloadConfigBuilder;
@@ -33,6 +34,8 @@ import de.flapdoodle.embed.mongo.config.MongodConfigBuilder;
 import de.flapdoodle.embed.mongo.config.RuntimeConfigBuilder;
 import de.flapdoodle.embed.mongo.distribution.Version;
 import de.flapdoodle.embed.process.config.IRuntimeConfig;
+
+import org.junit.After;
 import org.junit.Before;
 
 import java.io.IOException;
@@ -56,6 +59,9 @@ public abstract class EmbeddedMongoTest {
     private static final String DB_NAME = "jenkinsbfa";
 
     private static String mongoURL = System.getProperty(EmbeddedMongoTest.class.getName() + ".mongoURL");
+
+    private MongodExecutable mongodExe = null;
+    private MongodProcess mongodProc = null;
 
     /**
      * Sets up an instance of {@link MongoDBKnowledgeBase} backed up by a real MongoDB, to be used for testing.
@@ -83,11 +89,18 @@ public abstract class EmbeddedMongoTest {
         }
 
         IMongodConfig conf = new MongodConfigBuilder().version(Version.Main.V3_6).build();
-        MongodExecutable mongodExe = runtime.prepare(conf);
-        mongodExe.start();
+        mongodExe = runtime.prepare(conf);
+        mongodProc = mongodExe.start();
 
         int port = conf.net().getPort();
         knowledgeBase = new MongoDBKnowledgeBase(LOCALHOST, port, DB_NAME, null, null, true, false);
     }
 
+    @After
+    public void tearDown() {
+        if (this.mongodProc != null) {
+            this.mongodProc.stop();
+            this.mongodExe.stop();
+        }
+    }
 }


### PR DESCRIPTION
When I run `mvn test` in this project, my computer collapses during execution of `EmbeddedMongoStatisticsTest` (it becomes awfully unresponsive, to the point of requiring a hard reboot). It seems to be because too many `mongod` processes are running: I've seen 10 of them during an execution of `EmbeddedMongoStatisticsTest`, before I interrupted Maven (while the computer was getting unresponsive already but still usable). I have no idea why "only" 10 MongoDB processes are an issue at all, but anyway, I thought it would be good to avoid that.

This PR fixes the issue by adding an `@After`-annotated method to the abstract `EmbeddedMongoTest` class. It was certainly missing, because in the `@Before` a MongoDB process is forked, which was never explicitly stopped.