### PR TITLE
Include line number of the found indication data

### DIFF
--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/db/MongoDBKnowledgeBase.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/db/MongoDBKnowledgeBase.java
@@ -1016,6 +1016,7 @@ public class MongoDBKnowledgeBase extends KnowledgeBase {
                 foundIndicationObject.put("pattern", foundIndication.getPattern());
                 foundIndicationObject.put("matchingFile", foundIndication.getMatchingFile());
                 foundIndicationObject.put("matchingString", foundIndication.getMatchingString());
+                foundIndicationObject.put("matchingLine", foundIndication.getMatchingLine());
                 foundIndicationObjects.add(foundIndicationObject);
             }
             object.put("indications", foundIndicationObjects);

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureReader.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureReader.java
@@ -182,7 +182,8 @@ public abstract class FailureReader {
                         try {
                             List<Indication> wasBefore = firstOccurrences.get(cause);
                             if (wasBefore == null || !wasBefore.contains(indication)) {
-                                if (processIndication(build, currentFile, resultMap, line, cause, indication)) {
+                                if (processIndication(build, currentFile, resultMap, line, cause, indication,
+                                        currentLine)) {
                                     wasBefore = new ArrayList<Indication>();
                                     wasBefore.add(indication);
                                     firstOccurrences.put(cause, wasBefore);
@@ -245,6 +246,7 @@ public abstract class FailureReader {
      * @param line line with content
      * @param cause current cause
      * @param indication indication that should be checked
+     * @param lineNumber The line number of the indication
      * @return true if new indication was found
      */
     private static boolean processIndication(Run build,
@@ -252,7 +254,8 @@ public abstract class FailureReader {
                                              Map<FailureCause, List<FoundIndication>> causeIndicationsMap,
                                              String line,
                                              FailureCause cause,
-                                             Indication indication) {
+                                             Indication indication,
+                                             int lineNumber) {
         Pattern pattern = indication.getPattern();
 
         if (pattern.matcher(new InterruptibleCharSequence(line)).matches()) {
@@ -260,7 +263,8 @@ public abstract class FailureReader {
                                                     build,
                                                     pattern.toString(),
                                                     currentFile,
-                                                    ConsoleNote.removeNotes(line));
+                                                    ConsoleNote.removeNotes(line),
+                                                    lineNumber);
 
 
             putToMapWithList(causeIndicationsMap, cause, foundIndication);
@@ -334,7 +338,7 @@ public abstract class FailureReader {
                     Matcher matcher = pattern.matcher(new InterruptibleCharSequence(searchBuffer.toString()));
                     if (matcher.find()) {
                         foundIndication = new FoundIndication(build, pattern.pattern(), currentFile,
-                                removeConsoleNotes(matcher.group()));
+                                removeConsoleNotes(matcher.group()), -1);
                         break;
                     }
                     searchBuffer.delete(0, BUF_SIZE_BYTES - OVERLAP_BYTES);

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/indication/FoundIndication.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/indication/FoundIndication.java
@@ -49,15 +49,10 @@ public class FoundIndication {
      */
     protected static final String FILE_ENCODING = System.getProperty("file.encoding");
     private String matchingFile;
-    /**
-     * @deprecated, kept for backwards compatibility.
-     */
-    @Deprecated
-    private transient Integer matchingLine;
-
     private String pattern;
     private Run build;
     private String matchingString;
+    private Integer matchingLine;
 
     /**
      * Standard constructor.
@@ -66,13 +61,16 @@ public class FoundIndication {
      * @param originalPattern the original pattern we used to match.
      * @param matchingFile    the path to the file in which we found the match.
      * @param matchingString  the String that makes up the match.
+     * @param matchingLine    the line number of the found indication
      */
     public FoundIndication(Run build, String originalPattern,
-                           String matchingFile, String matchingString) {
+                           String matchingFile, String matchingString,
+                           Integer matchingLine) {
         this.pattern = originalPattern;
         this.matchingFile = matchingFile;
         this.build = build;
         this.matchingString = matchingString;
+        this.matchingLine = matchingLine;
     }
 
     /**
@@ -81,14 +79,17 @@ public class FoundIndication {
      * @param pattern the pattern we used to match.
      * @param matchingFile the path to the file in which we found the match.
      * @param matchingString the String that makes up the match.
+     * @param matchingLine the line number of the found indication
      */
     @JsonCreator
     public FoundIndication(@JsonProperty("pattern") String pattern,
             @JsonProperty("matchingFile") String matchingFile,
-            @JsonProperty("matchingString") String matchingString) {
+            @JsonProperty("matchingString") String matchingString,
+            @JsonProperty("matchingLine") Integer matchingLine) {
         this.pattern = pattern;
         this.matchingFile = matchingFile;
         this.matchingString = matchingString;
+        this.matchingLine = matchingLine;
     }
 
     /**
@@ -169,12 +170,10 @@ public class FoundIndication {
     }
 
     /**
-     * The old matching line number.
+     * The matching line number.
      *
      * @return the matching line number.
-     * @deprecated since 1.3.2, 1.4.0 replaced with {@link #getMatchingString()}.
      */
-    @Deprecated
     public int getMatchingLine() {
         if (matchingLine != null) {
             return matchingLine;

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/indication/FoundIndication.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/indication/FoundIndication.java
@@ -61,6 +61,36 @@ public class FoundIndication {
      * @param originalPattern the original pattern we used to match.
      * @param matchingFile    the path to the file in which we found the match.
      * @param matchingString  the String that makes up the match.
+     * @deprecated Use {@link #FoundIndication(Run, String, String, String, Integer)} instead
+     */
+    @Deprecated
+    public FoundIndication(Run build, String originalPattern,
+                           String matchingFile, String matchingString) {
+        this(build, originalPattern, matchingFile, matchingString, -1);
+    }
+
+    /**
+     * JSON Constructor.
+     *
+     * @param pattern the pattern we used to match.
+     * @param matchingFile the path to the file in which we found the match.
+     * @param matchingString the String that makes up the match.
+     * @deprecated Use {@link #FoundIndication(String, String, String, Integer)} instead
+     */
+    @Deprecated
+    public FoundIndication(@JsonProperty("pattern") String pattern,
+                           @JsonProperty("matchingFile") String matchingFile,
+                           @JsonProperty("matchingString") String matchingString) {
+        this(pattern, matchingFile, matchingString, -1);
+    }
+
+    /**
+     * Standard constructor.
+     *
+     * @param build           the build of this indication.
+     * @param originalPattern the original pattern we used to match.
+     * @param matchingFile    the path to the file in which we found the match.
+     * @param matchingString  the String that makes up the match.
      * @param matchingLine    the line number of the found indication
      */
     public FoundIndication(Run build, String originalPattern,

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/providers/FailureCauseProvider.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/providers/FailureCauseProvider.java
@@ -59,6 +59,7 @@ public class FailureCauseProvider extends MQDataProvider {
                     JSONObject foundIndicationJSONObject = new JSONObject();
                     foundIndicationJSONObject.put("pattern", indication.getPattern());
                     foundIndicationJSONObject.put("matchingString", indication.getMatchingString());
+                    foundIndicationJSONObject.put("matchingLine", indication.getMatchingLine());
                     foundIndicationsJSONArray.add(foundIndicationJSONObject);
                 }
                 failureCauseJSONObject.put("indications", foundIndicationsJSONArray);

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/FailureCauseProviderTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/FailureCauseProviderTest.java
@@ -46,7 +46,7 @@ import static org.mockito.Mockito.when;
  * @author Tomas Westling &lt;tomas.westling@axis.com&gt;
  */
 public class FailureCauseProviderTest {
-
+    private static final int MATCHING_LINE_NUMBER = 10;
     /**
      * Tests that the Json structure is correct after the FailureCauseProvider has done its thing.
      */
@@ -69,7 +69,8 @@ public class FailureCauseProviderTest {
                 null,
                 null);
         List<FoundIndication> foundIndications = new ArrayList<FoundIndication>();
-        FoundIndication foundIndication = new FoundIndication(null, "mypattern", "myfile", "mystring");
+        FoundIndication foundIndication = new FoundIndication(null, "mypattern", "myfile", "mystring",
+            MATCHING_LINE_NUMBER);
         foundIndications.add(foundIndication);
         FoundFailureCause foundFailureCause = new FoundFailureCause(failureCause, foundIndications);
         List<FoundFailureCause> foundFailureCauses = new ArrayList<FoundFailureCause>();
@@ -95,5 +96,6 @@ public class FailureCauseProviderTest {
         assertThat(cat.get(1), is("category2"));
         assertThat(((JSONObject)indicationsJson.get(0)).getString("pattern"), is("mypattern"));
         assertThat(((JSONObject)indicationsJson.get(0)).getString("matchingString"), is("mystring"));
+        assertThat(((JSONObject)indicationsJson.get(0)).getInt("matchingLine"), is(MATCHING_LINE_NUMBER));
     }
 }


### PR DESCRIPTION
The line number is needed for allowing us to figure out which
indicator was found first.

Note: In this PR, the linenumber will only be provided for single
line indicators. While it may be feasible to add line counting to
the multiline indicators, it's a complemetely different beast. The
multiline implementation uses a sliding search window mechanism and
line counting will incur some refactoring. If ever needed, it should
be added in a future PR.