### PR TITLE
Add Categories to Slack message improve UI and fix deprecations

### DIFF
--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/BuildFailureScanner.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/BuildFailureScanner.java
@@ -279,7 +279,7 @@ public class BuildFailureScanner extends RunListener<Run> {
      * @param buildNum - Build object
      * @param buildUrl - Full URL of build
      * @param scanLog - PrintStream for the build log
-     * @return String message if message successfully created, null otherwise
+     * @return String Slack message with failure name, category and description if message successfully created, null otherwise
      */
     public static String createSlackMessage(List<FoundFailureCause> foundCauseList,
             boolean notifySlackOfAllFailures, List<String> slackFailureCauseCategories,

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/BuildFailureScanner.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/BuildFailureScanner.java
@@ -279,7 +279,8 @@ public class BuildFailureScanner extends RunListener<Run> {
      * @param buildNum - Build object
      * @param buildUrl - Full URL of build
      * @param scanLog - PrintStream for the build log
-     * @return String Slack message with failure name, category and description if message successfully created, null otherwise
+     * @return String Slack message with failure name, category and description if message successfully created,
+     * null otherwise
      */
     public static String createSlackMessage(List<FoundFailureCause> foundCauseList,
             boolean notifySlackOfAllFailures, List<String> slackFailureCauseCategories,
@@ -290,11 +291,11 @@ public class BuildFailureScanner extends RunListener<Run> {
         /* Check if one of the failure causes for the build matches those specified in plugin's slack settings. */
         for (FoundFailureCause foundCause : foundCauseList) {
             if (notifySlackOfAllFailures) {
-                //Add two new lines between found categories
+                //Add two new lines between found Failure Causes
                 if (bufBuildFailCause.length() != 0) {
                     bufBuildFailCause.append("\n\n");
                 }
-                //Create list for slack message with failure Name, Cegory and Description from build
+                //Create list for slack message with failure Name, Category and Description from build
                 bufBuildFailCause.append("*Failure Name:* ");
                 bufBuildFailCause.append(foundCause.getName());
                 bufBuildFailCause.append("\n");
@@ -310,11 +311,11 @@ public class BuildFailureScanner extends RunListener<Run> {
                     for (String category : categories) {
                         if (failureCategoryMatches(category, slackFailureCauseCategories)) {
                             notifySlackOfFailure = true;
-                            //Add two new lines between found categoreis
+                            //Add two new lines between found Failure Causes
                             if (bufBuildFailCause.length() != 0) {
                                 bufBuildFailCause.append("\n\n");
                             }
-                            // Create list for slack message with failure Name, Cegory and Description from build
+                            // Create list for slack message with failure Name, Category and Description from build
                             bufBuildFailCause.append("*Failure Name:* ");
                             bufBuildFailCause.append(foundCause.getName());
                             bufBuildFailCause.append("\n");
@@ -335,9 +336,9 @@ public class BuildFailureScanner extends RunListener<Run> {
             SlackMessageProvider slack = new SlackMessageProvider();
 
             StringBuilder s = new StringBuilder("Job *\"" + buildName + "\"*");
-            s.append(" build *#" + buildNum + "* FAILED due to following failure causes: \n");
-            s.append(bufBuildFailCause.toString() + "\nSee ");
-            s.append(buildUrl + " for details.");
+            s.append(" build *#").append(buildNum).append("* FAILED due to following failure causes: \n");
+            s.append(bufBuildFailCause.toString()).append("\nSee ");
+            s.append(buildUrl).append(" for details.");
 
             slack.postToSlack(s.toString(), scanLog);
             return s.toString();

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/statistics/Statistics.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/statistics/Statistics.java
@@ -197,19 +197,20 @@ public class Statistics {
         this.failureCauseStatisticsList = failureCauseStatistics;
     }
 
-        /**
-         * deprecated, kept for backwards compatibility.
-         * @param projectName the project name.
-         * @param buildNumber the build number.
-         * @param startingTime the starting time.
-         * @param duration the duration.
-         * @param triggerCauses the causes that triggered this build.
-         * @param nodeName the name of the node this build ran on.
-         * @param master the master this build ran on.
-         * @param timeZoneOffset the time zone offset.
-         * @param result the result of the build.
-         * @param failureCauseStatistics the statistics for the FailureCauses.
-         */
+    /**
+     * Deprecated statistics constructor.
+     * @param projectName the project name.
+     * @param buildNumber the build number.
+     * @param startingTime the starting time.
+     * @param duration the duration.
+     * @param triggerCauses the causes that triggered this build.
+     * @param nodeName the name of the node this build ran on.
+     * @param master the master this build ran on.
+     * @param timeZoneOffset the time zone offset.
+     * @param result the result of the build.
+     * @param failureCauseStatistics the statistics for the FailureCauses.
+     * @deprecated, kept for backwards compatibility.
+     */
     @Deprecated
     public Statistics(String projectName,
                       int buildNumber,

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/GerritMessageProviderExtensionTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/GerritMessageProviderExtensionTest.java
@@ -12,6 +12,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -25,6 +26,7 @@ import java.util.List;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({PluginImpl.class, Jenkins.class })
+@PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "javax.management.*"})
 public class GerritMessageProviderExtensionTest {
     private static final String JENKINS_URL =  "http://some.jenkins.com";
     private static final String BUILD_URL = "jobs/build/123";

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/GerritMessageProviderExtensionTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/GerritMessageProviderExtensionTest.java
@@ -12,7 +12,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -26,7 +25,6 @@ import java.util.List;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({PluginImpl.class, Jenkins.class })
-@PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "javax.management.*"})
 public class GerritMessageProviderExtensionTest {
     private static final String JENKINS_URL =  "http://some.jenkins.com";
     private static final String BUILD_URL = "jobs/build/123";

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/PluginImplTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/PluginImplTest.java
@@ -29,6 +29,7 @@ import jenkins.model.Jenkins;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -44,8 +45,8 @@ import static org.powermock.api.mockito.PowerMockito.when;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(Hudson.class)
+@PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "javax.management.*"})
 public class PluginImplTest {
-
     /**
      * Initial mocking.
      */

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/PluginImplTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/PluginImplTest.java
@@ -29,7 +29,6 @@ import jenkins.model.Jenkins;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -45,8 +44,8 @@ import static org.powermock.api.mockito.PowerMockito.when;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(Hudson.class)
-@PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "javax.management.*"})
 public class PluginImplTest {
+
     /**
      * Initial mocking.
      */

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/SlackMessageProviderTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/SlackMessageProviderTest.java
@@ -2,16 +2,17 @@ package com.sonyericsson.jenkins.plugins.bfa;
 
 import jenkins.model.Jenkins;
 import jenkins.plugins.slack.SlackNotifier;
-import org.apache.http.ssl.SSLInitializationException;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import static org.junit.Assert.assertEquals;
+
+import org.apache.http.ssl.SSLInitializationException;
 
 /**
  * Tests for the SlackMessageProvider class.
@@ -20,7 +21,6 @@ import static org.junit.Assert.assertEquals;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({PluginImpl.class, SlackNotifier.class, Jenkins.class})
-@PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "javax.management.*"})
 public class SlackMessageProviderTest {
     private SlackNotifier slackPlugin;
     private SlackNotifier.DescriptorImpl descriptor;

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/SlackMessageProviderTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/SlackMessageProviderTest.java
@@ -2,17 +2,16 @@ package com.sonyericsson.jenkins.plugins.bfa;
 
 import jenkins.model.Jenkins;
 import jenkins.plugins.slack.SlackNotifier;
-
+import org.apache.http.ssl.SSLInitializationException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import static org.junit.Assert.assertEquals;
-
-import org.apache.http.ssl.SSLInitializationException;
 
 /**
  * Tests for the SlackMessageProvider class.
@@ -21,6 +20,7 @@ import org.apache.http.ssl.SSLInitializationException;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({PluginImpl.class, SlackNotifier.class, Jenkins.class})
+@PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "javax.management.*"})
 public class SlackMessageProviderTest {
     private SlackNotifier slackPlugin;
     private SlackNotifier.DescriptorImpl descriptor;

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/db/EmbeddedMongoStatisticsTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/db/EmbeddedMongoStatisticsTest.java
@@ -75,7 +75,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(value = {PluginImpl.class, Jenkins.class})
-@PowerMockIgnore("javax.management.*") //Solves PowerMock issue 277
+@PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "javax.management.*"})
 public class EmbeddedMongoStatisticsTest extends EmbeddedMongoTest {
     // CS IGNORE MagicNumber FOR NEXT 600 LINES. REASON: Test data.
 

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/db/EmbeddedMongoStatisticsTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/db/EmbeddedMongoStatisticsTest.java
@@ -75,7 +75,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(value = {PluginImpl.class, Jenkins.class})
-@PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "javax.management.*"})
+@PowerMockIgnore("javax.management.*") //Solves PowerMock issue 277
 public class EmbeddedMongoStatisticsTest extends EmbeddedMongoTest {
     // CS IGNORE MagicNumber FOR NEXT 600 LINES. REASON: Test data.
 

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/db/LocalFileKnowledgeBaseTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/db/LocalFileKnowledgeBaseTest.java
@@ -26,14 +26,15 @@ package com.sonyericsson.jenkins.plugins.bfa.db;
 
 import com.sonyericsson.jenkins.plugins.bfa.PluginImpl;
 import com.sonyericsson.jenkins.plugins.bfa.model.FailureCause;
-import com.sonyericsson.jenkins.plugins.bfa.model.indication.BuildLogIndication;
 import com.sonyericsson.jenkins.plugins.bfa.model.FailureCauseModification;
+import com.sonyericsson.jenkins.plugins.bfa.model.indication.BuildLogIndication;
 import com.sonyericsson.jenkins.plugins.bfa.model.indication.Indication;
 import hudson.util.CopyOnWriteList;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -58,6 +59,7 @@ import static org.mockito.Mockito.when;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(PluginImpl.class)
+@PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "javax.management.*"})
 public class LocalFileKnowledgeBaseTest {
 
     private CopyOnWriteList<FailureCause> oldCauses;

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/db/LocalFileKnowledgeBaseTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/db/LocalFileKnowledgeBaseTest.java
@@ -26,15 +26,14 @@ package com.sonyericsson.jenkins.plugins.bfa.db;
 
 import com.sonyericsson.jenkins.plugins.bfa.PluginImpl;
 import com.sonyericsson.jenkins.plugins.bfa.model.FailureCause;
-import com.sonyericsson.jenkins.plugins.bfa.model.FailureCauseModification;
 import com.sonyericsson.jenkins.plugins.bfa.model.indication.BuildLogIndication;
+import com.sonyericsson.jenkins.plugins.bfa.model.FailureCauseModification;
 import com.sonyericsson.jenkins.plugins.bfa.model.indication.Indication;
 import hudson.util.CopyOnWriteList;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -59,7 +58,6 @@ import static org.mockito.Mockito.when;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(PluginImpl.class)
-@PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "javax.management.*"})
 public class LocalFileKnowledgeBaseTest {
 
     private CopyOnWriteList<FailureCause> oldCauses;

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCauseTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCauseTest.java
@@ -42,7 +42,6 @@ import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.mockito.Matchers;
 import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -63,6 +62,7 @@ import static org.powermock.api.mockito.PowerMockito.doCallRealMethod;
 import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
+
 /**
  * Tests for {@link FailureCause}.
  *
@@ -70,7 +70,6 @@ import static org.powermock.api.mockito.PowerMockito.when;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Jenkins.class, PluginImpl.class })
-@PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "javax.management.*"})
 public class FailureCauseTest {
 
     private PluginImpl pluginMock;

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCauseTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCauseTest.java
@@ -42,6 +42,7 @@ import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.mockito.Matchers;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -62,7 +63,6 @@ import static org.powermock.api.mockito.PowerMockito.doCallRealMethod;
 import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
-
 /**
  * Tests for {@link FailureCause}.
  *
@@ -70,6 +70,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Jenkins.class, PluginImpl.class })
+@PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "javax.management.*"})
 public class FailureCauseTest {
 
     private PluginImpl pluginMock;

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/sod/ScanOnDemandTaskTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/sod/ScanOnDemandTaskTest.java
@@ -48,6 +48,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.reflect.Whitebox;
@@ -65,6 +66,7 @@ import static org.junit.Assert.assertEquals;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Jenkins.class, PluginImpl.class, ScanOnDemandQueue.class, ScanOnDemandTask.class })
+@PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "javax.management.*"})
 public class ScanOnDemandTaskTest {
 
     private AbstractProject mockproject;

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/sod/ScanOnDemandTaskTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/sod/ScanOnDemandTaskTest.java
@@ -48,7 +48,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.reflect.Whitebox;
@@ -66,7 +65,6 @@ import static org.junit.Assert.assertEquals;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Jenkins.class, PluginImpl.class, ScanOnDemandQueue.class, ScanOnDemandTask.class })
-@PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "javax.management.*"})
 public class ScanOnDemandTaskTest {
 
     private AbstractProject mockproject;


### PR DESCRIPTION
Add Failure Categories to Slack message.
Add Failure Description to slack message.
Improve UI.
Fix a case where you end up getting information about two failing cases when you are only looking to get messages for one.
Remove deprecated
java.util.concurrent.Future;
in favor of
hudson.model.queue.QueueTaskFuture;

Improve slack Message unit tests
<img width="716" alt="Screen Shot 2020-06-15 at 1 05 07 PM" src="https://user-images.githubusercontent.com/5922430/84701550-0fedd500-af0a-11ea-9b0b-83c84cd75ba2.png">

An example of multiple categories for a Cause:
<img width="784" alt="Screen Shot 2020-07-14 at 10 53 19 AM" src="https://user-images.githubusercontent.com/5922430/87459775-afad8a00-c5c0-11ea-9fc9-be59c44c8f89.png">

An example of multiple Failures in one message:
<img width="793" alt="Screen Shot 2020-07-14 at 10 55 46 AM" src="https://user-images.githubusercontent.com/5922430/87459868-d075df80-c5c0-11ea-8385-d2fff38abedc.png">
