### PR TITLE
Analyze all projects in RunListener.onCompleted() scope (again)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,13 +11,13 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.55</version>
+        <version>4.19</version>
     </parent>
 
     <properties>
         <revision>2.0.1</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.164.3</jenkins.version>
+        <jenkins.version>2.222.4</jenkins.version>
         <java.level>8</java.level>
         <checkstyle.version>3.1.1</checkstyle.version>
         <configuration-as-code.version>1.35</configuration-as-code.version>
@@ -85,17 +85,22 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>log4j-over-slf4j</artifactId>
-            <version>1.7.26</version>
+            <version>1.7.30</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
-            <version>1.7.26</version>
+            <version>1.7.30</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.26</version>
+            <version>1.7.30</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <version>1.7.30</version>
         </dependency>
         <dependency>
             <groupId>com.sonyericsson.hudson.plugins.gerrit</groupId>
@@ -151,7 +156,7 @@
         <dependency>
             <groupId>com.sonymobile.jenkins.plugins.mq</groupId>
             <artifactId>mq-notifier</artifactId>
-            <version>1.2.1</version>
+            <version>1.3.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-validator</groupId>
@@ -202,6 +207,12 @@
             <version>2.11.0</version>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-api</artifactId>
+            <version>2.42</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
             <version>2.11.0</version>
@@ -214,7 +225,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.9</version>
+            <version>3.11</version>
         </dependency>
         <dependency>
             <groupId>commons-net</groupId>
@@ -240,12 +251,11 @@
             <version>${configuration-as-code.version}</version>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.19</version>
-            <scope>test</scope>
+            <version>1.20</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -278,25 +288,30 @@
             <version>1.2</version>
             <optional>true</optional>
         </dependency>
-        <!-- Test dependencies -->
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-aggregator</artifactId>
-            <version>2.5</version>
-            <scope>test</scope>
-            <exclusions>
-                <!-- it comes from jackson2-api plugin instead -->
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-annotations</artifactId>
-                </exclusion>
-            </exclusions>
+            <artifactId>workflow-job</artifactId>
+            <version>2.41</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>scm-api</artifactId>
-            <version>2.2.6</version>
-            <scope>test</scope>
+            <version>2.6.4</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>script-security</artifactId>
+            <version>1.75</version>
+            <optional>true</optional>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.jenkins-ci.plugins.workflow/workflow-step-api -->
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-step-api</artifactId>
+            <version>2.23</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
@@ -317,6 +332,12 @@
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
             <version>2.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>git-client</artifactId>
+            <version>1.21.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -410,11 +431,6 @@
                     <!-- Optional directory to put findbugs xdoc xml report -->
                     <!--<xmlOutputDirectory>target/site</xmlOutputDirectory>-->
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jxr-plugin</artifactId>
-                <version>2.3</version>
             </plugin>
         </plugins>
     </reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -441,14 +441,14 @@
     </scm>
     <reporting>
         <plugins>
-            <!--plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <source>8</source>
                     <target>8</target>
                 </configuration>
-            </plugin-->
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -313,6 +313,13 @@
             <version>2.23</version>
             <optional>true</optional>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.jenkins-ci.plugins/pipeline-build-step -->
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>pipeline-build-step</artifactId>
+            <version>2.5.1</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
@@ -410,6 +417,14 @@
     </scm>
     <reporting>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.sonyericsson.jenkins.plugins.bfa</groupId>
     <artifactId>build-failure-analyzer</artifactId>
@@ -78,12 +79,6 @@
     <dependencies>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-jdk14</artifactId>
-            <version>1.7.26</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
             <artifactId>log4j-over-slf4j</artifactId>
             <version>1.7.30</version>
         </dependency>
@@ -150,7 +145,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>token-macro</artifactId>
-            <version>2.2</version>
+            <version>2.5</version>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -238,6 +233,30 @@
             <version>1.3</version>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-cps</artifactId>
+            <version>2.24</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-durable-task-step</artifactId>
+            <version>2.8</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkinsci.plugins</groupId>
+            <artifactId>pipeline-model-definition</artifactId>
+            <version>1.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-scm-step</artifactId>
+            <version>2.3</version>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>io.jenkins</groupId>
@@ -306,14 +325,18 @@
             <version>1.75</version>
             <optional>true</optional>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/org.jenkins-ci.plugins.workflow/workflow-step-api -->
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
             <version>2.23</version>
             <optional>true</optional>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/org.jenkins-ci.plugins/pipeline-build-step -->
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-support</artifactId>
+            <version>3.8</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>pipeline-build-step</artifactId>
@@ -411,20 +434,21 @@
     </build>
     <scm>
         <connection>scm:git:ssh://github.com/jenkinsci/build-failure-analyzer-plugin.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com/jenkinsci/build-failure-analyzer-plugin.git</developerConnection>
+        <developerConnection>scm:git:ssh://git@github.com/jenkinsci/build-failure-analyzer-plugin.git
+        </developerConnection>
         <url>https://github.com/jenkinsci/build-failure-analyzer-plugin</url>
         <tag>${scmTag}</tag>
     </scm>
     <reporting>
         <plugins>
-            <plugin>
+            <!--plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <source>8</source>
                     <target>8</target>
                 </configuration>
-            </plugin>
+            </plugin-->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/BuildFailureScanner.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/BuildFailureScanner.java
@@ -41,7 +41,6 @@ import hudson.Util;
 import hudson.init.InitMilestone;
 import hudson.init.Initializer;
 import hudson.matrix.MatrixProject;
-import hudson.model.AbstractBuild;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.model.listeners.RunListener;

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/BuildFailureScanner.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/BuildFailureScanner.java
@@ -115,20 +115,8 @@ public class BuildFailureScanner extends RunListener<Run> {
 
     @Override
     public void onCompleted(Run run, @Nonnull TaskListener listener) {
-        if (run instanceof AbstractBuild) {
-            logger.entering(getClass().getName(), "onCompleted");
-
-            doScan(run);
-        }
-    }
-
-    @Override
-    public void onFinalized(Run run) {
-        if (!(run instanceof AbstractBuild)) {
-            logger.entering(getClass().getName(), "onFinalized");
-
-            doScan(run);
-        }
+        logger.entering(getClass().getName(), "onCompleted");
+        doScan(run);
     }
 
     private void doScan(Run build) {

--- a/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/CauseManagement/index.groovy
+++ b/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/CauseManagement/index.groovy
@@ -32,7 +32,11 @@ def f = namespace(lib.FormTagLib)
 def l = namespace(lib.LayoutTagLib)
 def j = namespace(lib.JenkinsTagLib)
 
-l.layout(permission: PluginImpl.VIEW_PERMISSION, norefresh: true) {
+// Check permission manually. Using permissions layout() from groovy breaks view.jelly.
+// Long story short, view.jelly interprets the exception text as jelly tags, which leads
+// to a JellyTagException (internal server error).
+Jenkins.get().checkPermission(PluginImpl.VIEW_PERMISSION)
+l.layout(norefresh: true) {
   l.header(title: _("Failure Cause Management - Confirm Remove"))
 
   def management = CauseManagement.getInstance();

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/FailureCauseWorkFlowTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/FailureCauseWorkFlowTest.java
@@ -76,7 +76,7 @@ public class FailureCauseWorkFlowTest {
     @Test
     public void testFailureCausesWhenNotFailed() throws Exception {
         WorkflowJob proj = j.jenkins.createProject(WorkflowJob.class, "proj");
-        proj.setDefinition(new CpsFlowDefinition("println('hello')"));
+        proj.setDefinition(new CpsFlowDefinition("//Do nothing!"));
         WorkflowRun run = j.assertBuildStatusSuccess(proj.scheduleBuild2(0));
         FailureCauseBuildAction action = run.getAction(FailureCauseBuildAction.class);
         assertNull(action);


### PR DESCRIPTION
In PR #103 the scope was changed for workflow jobs (and others) to
carry out the BFA analysis in RunListener.onFinalized() scope due
to JENKINS-42755.

I argue that this was the wrong way to remedy the mentioned issue
due to following factors:

1. RunListener.fireCompleted() is executed before a build is
released. When we say 'released' we mean that any waiting upstream
builds can continue (or downstream builds can be triggered).

2. RunListener.fireFinalized() is executed after the build has
been released.

The Build Failure Analyzer plugin was originally written to be
executing in RunListener.onCompleted() scope and then wait for the
analysis to be completed. This means that the waiting upstream
build will wait for its downstream builds to complete (and be
analysed) before doing its own aggregation and analysis.

Changing this behaviour is problematic, since the upstream job is
now (since PR #103) already given the OK to continue executing
before the BFA analysis is executed. And we will see a really bad
racing condition where the upstream build could complete its log
analysis before the downsteam build. This is extra problematic,
if you want to emit messages (mq-notifier plugin) with this kind
of data aggregated.

PR #103 is a complete behavioural change, which essentially hinders
aggregation (and acting upon) issues found in downstream jobs.

I argue that the correct fix should have been in the WorkflowRun,
ensuring that any error messages are printed in the log before the
RunListener.fireCompleted() is executed. This is how most (all?)
other job types handle it today.

In https://github.com/jenkinsci/workflow-job-plugin/pull/184
this behaviour was finally changed to print errors before
RunListener.onCompleted() is fired, and BFA will now be able
to pick up all issues produced in the console log from
RunListener.onCompleted().

NOTE: This PR should not be merged until a new release of the
Workflow Job Plugin is released.

More details can be found in
https://github.com/jenkinsci/workflow-job-plugin/pull/184.

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
