### PR TITLE
Integration with the Metrics plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ recognition of why the build failed.
 ## Guides
 
  * [Azure Cosmos DB](docs/azure.md)
+ * [Metrics Integration](docs/metrics.md)
 
 ## Community Resources
  * [Changelog](https://github.com/jenkinsci/build-failure-analyzer-plugin/releases)

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,31 @@
+# Metrics Integration
+
+This is a guide for the integration with the [Metrics plugin](https://plugins.jenkins.io/metrics/).
+
+## Metrics
+
+The integration provides counters for each individual cause and category that you create. These counters will reset to zero when jenkins is restarted. The format for the metrics created is `jenkins_bfa_category_<category name>` for each category and `jenkins_bfa_cause_<cause name>` for each cause. The category and cause names will be escaped by the metrics api to replace any spaces with underscores. 
+
+## Exporting
+
+To export the BFA metrics you can use any plugin that integrates with the Metrics plugin.
+
+### Prometheus
+The [prometheus plugin](https://plugins.jenkins.io/prometheus/)
+To restructure the metrics into the form that prometheus expects you can add the following into your scrape config:
+
+```yaml
+metric_relabel_configs:
+  - source_labels: [__name__]
+    regex: 'jenkins_bfa_category_(.*)'
+    target_label: 'category'
+  - source_labels: [__name__]
+    regex: 'jenkins_bfa_cause_(.*)'
+    target_label: 'cause'
+  - source_labels: [__name__]
+    regex: 'jenkins_bfa_(.*)_(.*)'
+    replacement: 'jenkins_bfa'
+    target_label: __name__ 
+```
+
+This will provide a metric called `jenkins_bfa` with labels for the category and specific cause.

--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <version>2.8</version>
+            <version>2.15</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -375,6 +375,11 @@
             <artifactId>de.flapdoodle.embed.mongo</artifactId>
             <version>2.1.1</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>metrics</artifactId>
+            <version>4.0.2.6</version>
         </dependency>
     </dependencies>
     <build>

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/BuildFailureScanner.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/BuildFailureScanner.java
@@ -25,6 +25,8 @@
 
 package com.sonyericsson.jenkins.plugins.bfa;
 
+import static com.sonyericsson.jenkins.plugins.bfa.MetricsManager.incCounters;
+
 import com.sonyericsson.jenkins.plugins.bfa.model.FailureCause;
 import com.sonyericsson.jenkins.plugins.bfa.model.FailureCauseBuildAction;
 import com.sonyericsson.jenkins.plugins.bfa.model.FailureCauseDisplayData;
@@ -186,6 +188,10 @@ public class BuildFailureScanner extends RunListener<Run> {
                 foundCauseList.addAll(findFailedTests(build, scanLog));
             } else {
                 foundCauseList = foundCauseListToLog;
+            }
+
+            for (FoundFailureCause cause : foundCauseList) {
+                incCounters(cause);
             }
 
             List<String> fallbackCategories = PluginImpl.getInstance().getFallbackCategories();

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/MetricsManager.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/MetricsManager.java
@@ -1,0 +1,58 @@
+package com.sonyericsson.jenkins.plugins.bfa;
+
+import com.codahale.metrics.MetricRegistry;
+import com.sonyericsson.jenkins.plugins.bfa.model.IFailureCauseMetricData;
+import jenkins.metrics.api.Metrics;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.SortedSet;
+
+public final class MetricsManager {
+    static final String CAUSEPREFIX = "jenkins_bfa.cause.";
+    static final String CATEGORYPREFIX = "jenkins_bfa.category.";
+
+    private MetricsManager() {
+    }
+
+    private static Set<String> getMetricNames(IFailureCauseMetricData cause) {
+        Set<String> metrics = new HashSet<String>();
+        metrics.add(CAUSEPREFIX + cause.getName());
+        List<String> categoriesForCause = cause.getCategories();
+        if (categoriesForCause != null) {
+            for (String string : categoriesForCause) {
+                metrics.add(CATEGORYPREFIX + string);
+            }
+        }
+        return metrics;
+    }
+
+    /**
+     * Add metrics into the MetricRegistry from the Metrics plugin.
+     *
+     * @param cause The Cause to add metrics for
+     */
+    public static void addMetric(IFailureCauseMetricData cause) {
+        MetricRegistry metricRegistry = Metrics.metricRegistry();
+        SortedSet<String> existingMetrics = metricRegistry.getNames();
+        Set<String> metrics = getMetricNames(cause);
+        for (String metric : metrics) {
+            if (!existingMetrics.contains(metric)) {
+                metricRegistry.counter(metric);
+            }
+        }
+    }
+
+    /**
+     * Increment caounters for the metric and its categories.
+     * @param cause The cause to increment counters for
+     */
+    public static void incCounters(IFailureCauseMetricData cause) {
+        MetricRegistry metricRegistry = Metrics.metricRegistry();
+        Set<String> metrics = getMetricNames(cause);
+        for (String metric : metrics) {
+            metricRegistry.counter(metric).inc();
+        }
+    }
+}

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/db/LocalFileKnowledgeBase.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/db/LocalFileKnowledgeBase.java
@@ -24,6 +24,7 @@
 
 package com.sonyericsson.jenkins.plugins.bfa.db;
 
+import static com.sonyericsson.jenkins.plugins.bfa.MetricsManager.addMetric;
 import static hudson.Util.fixEmpty;
 
 import java.io.IOException;
@@ -55,6 +56,9 @@ import org.kohsuke.stapler.DataBoundConstructor;
 public class LocalFileKnowledgeBase extends KnowledgeBase {
 
     private Map<String, FailureCause> causes;
+
+
+
 
     /**
      * Standard constructor. Used for legacy conversion.
@@ -125,6 +129,7 @@ public class LocalFileKnowledgeBase extends KnowledgeBase {
 
     @Override
     public FailureCause saveCause(FailureCause cause) throws IOException {
+        addMetric(cause);
         if (fixEmpty(cause.getId()) == null) {
             return addCause(cause);
         } else {
@@ -183,7 +188,9 @@ public class LocalFileKnowledgeBase extends KnowledgeBase {
 
     @Override
     public void start() {
-        //TODO should something be done here?
+        for (Map.Entry<String, FailureCause> entry : causes.entrySet()) {
+            addMetric(entry.getValue());
+        }
     }
 
     @Override

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/db/MongoDBKnowledgeBase.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/db/MongoDBKnowledgeBase.java
@@ -38,6 +38,7 @@ import com.mongodb.client.MongoClient;
 import static com.mongodb.client.model.Filters.not;
 import static com.mongodb.client.model.Filters.exists;
 import static com.mongodb.client.model.Filters.eq;
+import static com.sonyericsson.jenkins.plugins.bfa.MetricsManager.addMetric;
 
 import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoCursor;
@@ -58,6 +59,7 @@ import hudson.util.FormValidation;
 import hudson.util.Secret;
 
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
@@ -81,8 +83,6 @@ import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.mongojack.JacksonMongoCollection;
 import org.mongojack.internal.MongoJackModule;
-
-import java.util.Collection;
 
 
 /**
@@ -211,6 +211,10 @@ public class MongoDBKnowledgeBase extends KnowledgeBase {
     @Override
     public synchronized void start() {
         initCache();
+        cache.updateCache();
+        for (FailureCause entry : getCauseNames()) {
+            addMetric(entry);
+        }
     }
 
     @Override
@@ -328,6 +332,7 @@ public class MongoDBKnowledgeBase extends KnowledgeBase {
 
     @Override
     public FailureCause saveCause(FailureCause cause) {
+        addMetric(cause);
         return saveCause(cause, true);
     }
 

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCause.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCause.java
@@ -69,7 +69,7 @@ import java.util.logging.Logger;
  * @author Tomas Westling &lt;thomas.westling@sonyericsson.com&gt;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class FailureCause implements Serializable, Action, Describable<FailureCause> {
+public class FailureCause implements Serializable, Action, Describable<FailureCause>, IFailureCauseMetricData {
     private static final Logger logger = Logger.getLogger(FailureCause.class.getName());
     private String id;
     private String name;

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FoundFailureCause.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FoundFailureCause.java
@@ -42,7 +42,7 @@ import com.sonyericsson.jenkins.plugins.bfa.model.indication.Indication;
  * @author Tomas Westling &lt;tomas.westling@sonymobile.com&gt;
  */
 @ExportedBean
-public class FoundFailureCause {
+public class FoundFailureCause implements IFailureCauseMetricData {
     private static final Logger logger = Logger.getLogger(FoundFailureCause.class.getName());
 
     private final String id;

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/IFailureCauseMetricData.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/IFailureCauseMetricData.java
@@ -1,0 +1,17 @@
+package com.sonyericsson.jenkins.plugins.bfa.model;
+
+import java.util.List;
+
+public interface IFailureCauseMetricData {
+    /**
+     * Getter for the name.
+     * @return the name
+     */
+    String getName();
+
+    /**
+     * Getter for the categories.
+     * @return the categories
+     */
+    List<String> getCategories();
+}

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/MetricsManagerTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/MetricsManagerTest.java
@@ -1,0 +1,82 @@
+package com.sonyericsson.jenkins.plugins.bfa;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.MetricRegistry;
+
+import com.sonyericsson.jenkins.plugins.bfa.model.FailureCause;
+import com.sonyericsson.jenkins.plugins.bfa.model.indication.BuildLogIndication;
+import com.sonyericsson.jenkins.plugins.bfa.model.indication.Indication;
+import jenkins.metrics.api.Metrics;
+
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.List;
+
+import static com.sonyericsson.jenkins.plugins.bfa.MetricsManager.addMetric;
+import static com.sonyericsson.jenkins.plugins.bfa.MetricsManager.incCounters;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+
+/**
+ * Tests for {@link MetricsManager}.
+ */
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({MetricRegistry.class})
+public class MetricsManagerTest {
+    @Mock
+    private MetricRegistry metricRegistry;
+    @Mock
+    private Counter counter;
+
+    private List<Indication> indications;
+    private Indication indication;
+    private FailureCause mockedCause;
+
+
+    /**
+     * Common stuff to set up for the tests.
+     */
+    @Before
+    public void setUp() {
+        indications = new LinkedList<Indication>();
+        indication = new BuildLogIndication("something");
+        indications.add(indication);
+        mockedCause = new FailureCause("id", "myFailureCause", "description", "comment", new Date(),
+                "category", indications, null);
+
+        PowerMockito.mockStatic(Metrics.class);
+        PowerMockito.when(Metrics.metricRegistry()).thenReturn(metricRegistry);
+        PowerMockito.when(metricRegistry.counter(Mockito.anyString())).thenReturn(counter);
+    }
+
+    /**
+     * Test that the case and category counters are created from a FailureCause.
+     */
+    public void testAddMetric() {
+        addMetric(mockedCause);
+
+        verify(metricRegistry, times(1)).counter("jenkins_bfa.cause.myFailureCause");
+        verify(metricRegistry, times(1)).counter("jenkins_bfa.category.category");
+    }
+
+    /**
+     * Test that the cause and category counters are incremented for a Failurecasue.
+     */
+    public void testIncCounters() {
+        incCounters(mockedCause);
+
+        verify(metricRegistry, times(1)).counter("jenkins_bfa.cause.myFailureCause").inc();
+        verify(metricRegistry, times(1)).counter("jenkins_bfa.category.category").inc();
+    }
+
+}

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/db/LocalFileKnowledgeBaseTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/db/LocalFileKnowledgeBaseTest.java
@@ -37,6 +37,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -53,7 +54,9 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
 
 /**
  * Tests for {@link LocalFileKnowledgeBase}.
@@ -131,6 +134,7 @@ public class LocalFileKnowledgeBaseTest {
         assertNotNull(expected.getId());
         assertFalse(expected.getId().isEmpty());
         assertSame(expected, kb.getCause(expected.getId()));
+
     }
 
     /**
@@ -166,6 +170,7 @@ public class LocalFileKnowledgeBaseTest {
                 "", expected.getIndications(), expected.getModifications());
         assertSame(toSave, kb.saveCause(toSave));
         assertNotSame(expected, kb.getCause(toSave.getId()));
+        verify(metricRegistry, times(1)).counter(Mockito.anyString());
     }
 
     /**

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/db/LocalFileKnowledgeBaseTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/db/LocalFileKnowledgeBaseTest.java
@@ -24,15 +24,19 @@
 
 package com.sonyericsson.jenkins.plugins.bfa.db;
 
+import com.codahale.metrics.MetricRegistry;
 import com.sonyericsson.jenkins.plugins.bfa.PluginImpl;
 import com.sonyericsson.jenkins.plugins.bfa.model.FailureCause;
 import com.sonyericsson.jenkins.plugins.bfa.model.indication.BuildLogIndication;
 import com.sonyericsson.jenkins.plugins.bfa.model.FailureCauseModification;
 import com.sonyericsson.jenkins.plugins.bfa.model.indication.Indication;
 import hudson.util.CopyOnWriteList;
+import jenkins.metrics.api.Metrics;
+import jenkins.model.Jenkins;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -57,12 +61,19 @@ import static org.mockito.Mockito.when;
  * @author Robert Sandell &lt;robert.sandell@sonyericsson.com&gt;
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(PluginImpl.class)
+@PrepareForTest({PluginImpl.class, Jenkins.class, Metrics.class, MetricRegistry.class})
 public class LocalFileKnowledgeBaseTest {
 
     private CopyOnWriteList<FailureCause> oldCauses;
     private FailureCause olle;
     private FailureCause existingCause;
+
+    @Mock
+    private Jenkins jenkins;
+    @Mock
+    private Metrics metricsPlugin;
+    @Mock
+    private MetricRegistry metricRegistry;
 
     /**
      * Some usable test data for most tests.
@@ -80,6 +91,12 @@ public class LocalFileKnowledgeBaseTest {
         PluginImpl mock = PowerMockito.mock(PluginImpl.class);
         PowerMockito.mockStatic(PluginImpl.class);
         PowerMockito.when(PluginImpl.getInstance()).thenReturn(mock);
+
+        PowerMockito.mockStatic(Jenkins.class);
+        PowerMockito.mockStatic(Metrics.class);
+        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
+        PowerMockito.when(jenkins.getPlugin(Metrics.class)).thenReturn(metricsPlugin);
+        PowerMockito.when(metricsPlugin.metricRegistry()).thenReturn(metricRegistry);
     }
 
     /**

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/db/MongoDBKnowledgeBaseTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/db/MongoDBKnowledgeBaseTest.java
@@ -41,6 +41,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Matchers;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mongojack.JacksonMongoCollection;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -58,6 +59,8 @@ import static junit.framework.Assert.assertSame;
 import static junit.framework.Assert.assertTrue;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.when;
 
@@ -180,6 +183,7 @@ public class MongoDBKnowledgeBaseTest {
         FailureCause addedCause = kb.saveCause(mockedCause);
         assertNotNull(addedCause);
         assertSame(mockedCause, addedCause);
+        verify(metricRegistry, times(2)).counter(Mockito.anyString());
     }
 
     /**

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCauseTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCauseTest.java
@@ -24,6 +24,7 @@
 
 package com.sonyericsson.jenkins.plugins.bfa.model;
 
+import com.codahale.metrics.MetricRegistry;
 import com.sonyericsson.jenkins.plugins.bfa.CauseManagement;
 import com.sonyericsson.jenkins.plugins.bfa.PluginImpl;
 import com.sonyericsson.jenkins.plugins.bfa.db.KnowledgeBase;
@@ -33,6 +34,7 @@ import com.sonyericsson.jenkins.plugins.bfa.model.indication.Indication;
 import hudson.model.AutoCompletionCandidates;
 import hudson.model.Failure;
 import hudson.util.FormValidation;
+import jenkins.metrics.api.Metrics;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.junit.Before;
@@ -41,6 +43,7 @@ import org.junit.runner.RunWith;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.mockito.Matchers;
+import org.mockito.Mock;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -69,12 +72,19 @@ import static org.powermock.api.mockito.PowerMockito.when;
  * @author Robert Sandell &lt;robert.sandell@sonyericsson.com&gt;
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({Jenkins.class, PluginImpl.class })
+@PrepareForTest({Jenkins.class, PluginImpl.class, Metrics.class, MetricRegistry.class })
 public class FailureCauseTest {
 
     private PluginImpl pluginMock;
     private KnowledgeBase baseMock;
     private FailureCause.FailureCauseDescriptor descriptor;
+
+    @Mock
+    private Jenkins jenkinsMock;
+    @Mock
+    private Metrics metricsPlugin;
+    @Mock
+    private MetricRegistry metricRegistry;
 
     /**
      * Runs before every test.
@@ -87,7 +97,6 @@ public class FailureCauseTest {
         mockStatic(PluginImpl.class);
         when(PluginImpl.getInstance()).thenReturn(pluginMock);
 
-        Jenkins jenkinsMock = mock(Jenkins.class);
         mockStatic(Jenkins.class);
         when(Jenkins.getInstance()).thenReturn(jenkinsMock);
         doCallRealMethod().when(Jenkins.class);
@@ -95,6 +104,10 @@ public class FailureCauseTest {
 
         descriptor = new FailureCause.FailureCauseDescriptor();
         when(jenkinsMock.getDescriptorByType(FailureCause.FailureCauseDescriptor.class)).thenReturn(descriptor);
+
+        PowerMockito.mockStatic(Metrics.class);
+        PowerMockito.when(jenkinsMock.getPlugin(Metrics.class)).thenReturn(metricsPlugin);
+        PowerMockito.when(metricsPlugin.metricRegistry()).thenReturn(metricRegistry);
     }
 
     /**

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/sod/ScanOnDemandTaskTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/sod/ScanOnDemandTaskTest.java
@@ -23,6 +23,7 @@
  */
 package com.sonyericsson.jenkins.plugins.bfa.sod;
 
+import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.Lists;
 import com.sonyericsson.jenkins.plugins.bfa.PluginImpl;
 import com.sonyericsson.jenkins.plugins.bfa.model.FoundFailureCause;
@@ -43,10 +44,13 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+
+import jenkins.metrics.api.Metrics;
 import jenkins.model.Jenkins;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -64,11 +68,25 @@ import static org.junit.Assert.assertEquals;
  * @author shemeer.x.sulaiman@sonymobile.com&gt;
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({Jenkins.class, PluginImpl.class, ScanOnDemandQueue.class, ScanOnDemandTask.class })
+@PrepareForTest({
+        Jenkins.class,
+        PluginImpl.class,
+        ScanOnDemandQueue.class,
+        ScanOnDemandTask.class,
+        Metrics.class,
+        MetricRegistry.class
+})
 public class ScanOnDemandTaskTest {
 
     private AbstractProject mockproject;
     private PluginImpl pluginMock;
+
+    @Mock
+    private Jenkins jenkins;
+    @Mock
+    private Metrics metricsPlugin;
+    @Mock
+    private MetricRegistry metricRegistry;
 
     /**
      * Runs before every test.
@@ -81,6 +99,12 @@ public class ScanOnDemandTaskTest {
         mockStatic(PluginImpl.class);
         when(PluginImpl.getInstance()).thenReturn(pluginMock);
         when(PluginImpl.needToAnalyze(Result.FAILURE)).thenReturn(true);
+
+        PowerMockito.mockStatic(Jenkins.class);
+        PowerMockito.mockStatic(Metrics.class);
+        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
+        PowerMockito.when(jenkins.getPlugin(Metrics.class)).thenReturn(metricsPlugin);
+        PowerMockito.when(metricsPlugin.metricRegistry()).thenReturn(metricRegistry);
     }
 
     /**


### PR DESCRIPTION
This adds integration with the Metrics plugin to replace the graphs that were removed by version 2, this will allow users to integrate with there own metrics systems (e.g. Prometheus or Data Dog).
This uses a counter from the Metrics library which will reset when jenkins is restarted which was done for implementation simplicity.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
