### PR TITLE
[JENKINS-66014] Adding support  retryable writes.

### DIFF
--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/db/MongoDBKnowledgeBase.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/db/MongoDBKnowledgeBase.java
@@ -706,7 +706,10 @@ public class MongoDBKnowledgeBase extends KnowledgeBase {
         if (mongo == null) {
             StringBuilder connectionStringBuilder = new StringBuilder(host);
             connectionStringBuilder.append(":").append(port);
-            boolean disableRetryWrites = (retryWrites)? false : true;
+            boolean disableRetryWrites = true;
+            if(retryWrites){
+                disableRetryWrites = false;
+            }
             MongoClientSettings.Builder builder = MongoClientSettings.builder().applyToClusterSettings(
                     builder1 -> {
                         List<ServerAddress> hostlist = new LinkedList<ServerAddress>();

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/db/MongoDBKnowledgeBase.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/db/MongoDBKnowledgeBase.java
@@ -707,7 +707,7 @@ public class MongoDBKnowledgeBase extends KnowledgeBase {
             StringBuilder connectionStringBuilder = new StringBuilder(host);
             connectionStringBuilder.append(":").append(port);
             boolean disableRetryWrites = true;
-            if(retryWrites){
+            if (retryWrites) {
                 disableRetryWrites = false;
             }
             MongoClientSettings.Builder builder = MongoClientSettings.builder().applyToClusterSettings(

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/db/MongoDBKnowledgeBase.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/db/MongoDBKnowledgeBase.java
@@ -188,7 +188,7 @@ public class MongoDBKnowledgeBase extends KnowledgeBase {
     }
 
     /**
-     * Set whether or not disable retryWrites while connecting to the mongo server.
+     * enable or disable retryWrites while connecting to the mongo server.
      * @param retryWrites the retryWrites option
      */
     @DataBoundSetter
@@ -706,10 +706,6 @@ public class MongoDBKnowledgeBase extends KnowledgeBase {
         if (mongo == null) {
             StringBuilder connectionStringBuilder = new StringBuilder(host);
             connectionStringBuilder.append(":").append(port);
-            boolean disableRetryWrites = true;
-            if (retryWrites) {
-                disableRetryWrites = false;
-            }
             MongoClientSettings.Builder builder = MongoClientSettings.builder().applyToClusterSettings(
                     builder1 -> {
                         List<ServerAddress> hostlist = new LinkedList<ServerAddress>();
@@ -721,7 +717,7 @@ public class MongoDBKnowledgeBase extends KnowledgeBase {
 
                     }).applyToServerSettings(builder12 -> {
             }).applyToSocketSettings(builder13 -> builder13.connectTimeout((CONNECT_TIMEOUT), TimeUnit.MILLISECONDS)).
-                    applyToSslSettings(builder14 -> builder14.enabled(tls)).retryWrites(disableRetryWrites);
+                    applyToSslSettings(builder14 -> builder14.enabled(tls)).retryWrites(retryWrites);
 
             if (password != null && Util.fixEmpty(password.getPlainText()) != null) {
                 char[] pwd = password.getPlainText().toCharArray();

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/db/MongoDBKnowledgeBase.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/db/MongoDBKnowledgeBase.java
@@ -848,7 +848,7 @@ public class MongoDBKnowledgeBase extends KnowledgeBase {
          * @param userName the user name.
          * @param password the password.
          * @param tls the tls option.
-         * @param retrywrites the retry_writes option
+         * @param retryWrites the retry_writes option
          * @return {@link FormValidation#ok() } if can be done,
          *         {@link FormValidation#error(java.lang.String) } otherwise.
          */

--- a/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/db/MongoDBKnowledgeBase/config.jelly
+++ b/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/db/MongoDBKnowledgeBase/config.jelly
@@ -41,7 +41,7 @@
     <f:entry title="${%Use TLS connection}">
         <f:checkbox field="tls" />
     </f:entry>
-    <f:entry title="${%Disable RetryWrites}">
+    <f:entry title="${%Enable RetryWrites}">
         <f:checkbox field="retryWrites" />
     </f:entry>
     <f:entry title="${%Enable statistics logging}">

--- a/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/db/MongoDBKnowledgeBase/config.jelly
+++ b/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/db/MongoDBKnowledgeBase/config.jelly
@@ -41,11 +41,14 @@
     <f:entry title="${%Use TLS connection}">
         <f:checkbox field="tls" />
     </f:entry>
+    <f:entry title="${%Disable RetryWrites}">
+        <f:checkbox field="retryWrites" />
+    </f:entry>
     <f:entry title="${%Enable statistics logging}">
         <f:checkbox field="enableStatistics" default="true"/>
     </f:entry>
     <f:entry title="${%Enable statistics logging of successful builds}">
         <f:checkbox field="successfulLogging" default="false"/>
     </f:entry>
-    <f:validateButton title="Test Connection" progress="Testing..." method="testConnection" with="host,port,dbName,userName,password,tls"/>
+    <f:validateButton title="Test Connection" progress="Testing..." method="testConnection" with="host,port,dbName,userName,password,tls,retryWrites"/>
 </j:jelly>


### PR DESCRIPTION
Starting with MongoDB 4.2 compatible drivers, retryable writes is enabled by default. However, Amazon DocumentDB does not currently support retryable writes. I am adding a support to enable/disable that setting while using this plugin

Options
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
