### PR TITLE
Fix FailureCause constructor not passing comment argument

### DIFF
--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCause.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCause.java
@@ -171,7 +171,7 @@ public class FailureCause implements Serializable, Action, Describable<FailureCa
      * @param categories    the categories of this FailureCause.
      */
     public FailureCause(String name, String description, String comment, String categories) {
-        this(null, name, description, "", null, Arrays.<String>asList(Util.tokenize(categories)), null, null);
+        this(null, name, description, comment, null, Arrays.<String>asList(Util.tokenize(categories)), null, null);
     }
 
     /**


### PR DESCRIPTION
The constructor of class `FailureCause` `FailureCause(String name, String description, String comment, String categories)` is not passing the argument `comment` to the overloaded constructor.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
