### PR TITLE
Add metric category squashing per build feature

### DIFF
--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/BuildFailureScanner.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/BuildFailureScanner.java
@@ -190,9 +190,7 @@ public class BuildFailureScanner extends RunListener<Run> {
                 foundCauseList = foundCauseListToLog;
             }
 
-            for (FoundFailureCause cause : foundCauseList) {
-                incCounters(cause);
-            }
+            incCounters(foundCauseList, PluginImpl.getInstance().isMetricSquashingEnabled());
 
             List<String> fallbackCategories = PluginImpl.getInstance().getFallbackCategories();
 

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/MetricsManager.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/MetricsManager.java
@@ -45,14 +45,27 @@ public final class MetricsManager {
     }
 
     /**
-     * Increment caounters for the metric and its categories.
-     * @param cause The cause to increment counters for
+     * Increment counters for the metric and its categories.
+     * @param causes The cause to increment counters for
+     * @param squashCauses Whether or not to squash cause metrics
      */
-    public static void incCounters(IFailureCauseMetricData cause) {
+    public static void incCounters(List<? extends IFailureCauseMetricData> causes, boolean squashCauses) {
         MetricRegistry metricRegistry = Metrics.metricRegistry();
-        Set<String> metrics = getMetricNames(cause);
-        for (String metric : metrics) {
-            metricRegistry.counter(metric).inc();
+        if (squashCauses) {
+            Set<String> metrics = new HashSet<>();
+            for (IFailureCauseMetricData cause : causes) {
+                metrics.addAll(getMetricNames(cause));
+            }
+            for (String metric : metrics) {
+                metricRegistry.counter(metric).inc();
+            }
+        } else {
+            for (IFailureCauseMetricData cause : causes) {
+                Set<String> metrics = getMetricNames(cause);
+                for (String metric : metrics) {
+                    metricRegistry.counter(metric).inc();
+                }
+            }
         }
     }
 }

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/PluginImpl.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/PluginImpl.java
@@ -167,6 +167,8 @@ public class PluginImpl extends GlobalConfiguration {
     private Boolean testResultParsingEnabled;
     private String testResultCategories;
 
+    private Boolean metricSquashingEnabled;
+
     /**
      * ScanOnDemandVariable instance.
      */
@@ -495,6 +497,19 @@ public class PluginImpl extends GlobalConfiguration {
     }
 
     /**
+     * If metrics should be squashed to only unique categories per build.
+     *
+     * @return True if enabled.
+     */
+    public boolean isMetricSquashingEnabled() {
+        if (metricSquashingEnabled == null) {
+            return false;
+        } else {
+            return metricSquashingEnabled;
+        }
+    }
+
+    /**
      * Sets if this feature is enabled or not. When on all aborted builds will be ignored.
      *
      * @param doNotAnalyzeAbortedJob on or off.
@@ -534,6 +549,17 @@ public class PluginImpl extends GlobalConfiguration {
     @DataBoundSetter
     public void setTestResultCategories(String testResultCategories) {
         this.testResultCategories = testResultCategories;
+    }
+
+    /**
+     * Sets if metrics should be squashed to only unique categories per build.
+     * Default value is false.
+     *
+     * @param metricSquashingEnabled on or off.
+     */
+    @DataBoundSetter
+    public void setMetricSquashingEnabled(boolean metricSquashingEnabled) {
+        this.metricSquashingEnabled = metricSquashingEnabled;
     }
 
     /**

--- a/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/PluginImpl/config.jelly
+++ b/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/PluginImpl/config.jelly
@@ -86,8 +86,13 @@
             </f:property>
         </f:section>
         <f:entry title="${%Do not analyze aborted jobs}"
-                                help="/plugin/build-failure-analyzer/help/help-doNotAnalyzeAbortedJobs.html">
+                 help="/plugin/build-failure-analyzer/help/help-doNotAnalyzeAbortedJobs.html">
             <f:checkbox field="doNotAnalyzeAbortedJob" />
+        </f:entry>
+        <f:entry title="${%Squash failure metrics to unique categories for each build}"
+                 description="${%metricSquashingEnabledDescription}"
+                 help="/plugin/build-failure-analyzer/help/help-metricSquashingEnabled.html">
+            <f:checkbox field="metricSquashingEnabled" default="false" />
         </f:entry>
         <f:entry title="${%Max size of log file}" description="${%maxLogSize}">
             <f:textbox field="maxLogSize" />

--- a/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/PluginImpl/config.properties
+++ b/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/PluginImpl/config.properties
@@ -4,3 +4,4 @@ testResultParsingEnabledDescription=Treat failed test cases (as indicated by JUn
 testResultCategoriesDescription=A space-separated list of categories to use for failure causes representing failed test cases.
 maxLogSize=Log file with size that exceeds limit (in MB) would not be scanned, 0 - disables this check
 fallbackCategoriesDescription=Space separated list of category names that marks fallback causes. Fallback causes will only be applied if there are no non-fallback causes found.
+metricSquashingEnabledDescription=Prevents a single failed build from counting categories multiple times if multiple failures causes are identified with the same categories.

--- a/src/main/webapp/help/help-metricSquashingEnabled.html
+++ b/src/main/webapp/help/help-metricSquashingEnabled.html
@@ -1,0 +1,6 @@
+<div>
+"Squash failure metrics to unique categories for each build" option can be useful when a single failed build should
+    count towards each cause category exactly once. This is particularly useful when combined with the "Treat failed
+    test cases as failure causes." If numerous tests fail, "squash failure metrics" will prevent those categories
+    from being incremented for every single failed test, which can skew metrics significantly.
+</div>

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/MetricsManagerTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/MetricsManagerTest.java
@@ -4,11 +4,13 @@ import com.codahale.metrics.Counter;
 import com.codahale.metrics.MetricRegistry;
 
 import com.sonyericsson.jenkins.plugins.bfa.model.FailureCause;
+import com.sonyericsson.jenkins.plugins.bfa.model.IFailureCauseMetricData;
 import com.sonyericsson.jenkins.plugins.bfa.model.indication.BuildLogIndication;
 import com.sonyericsson.jenkins.plugins.bfa.model.indication.Indication;
 import jenkins.metrics.api.Metrics;
 
 import org.junit.Before;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -16,6 +18,8 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
@@ -31,28 +35,27 @@ import static org.mockito.Mockito.verify;
  */
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({MetricRegistry.class})
+@PrepareForTest({MetricRegistry.class, Metrics.class})
 public class MetricsManagerTest {
     @Mock
     private MetricRegistry metricRegistry;
     @Mock
     private Counter counter;
 
-    private List<Indication> indications;
-    private Indication indication;
     private FailureCause mockedCause;
-
+    private List<? extends IFailureCauseMetricData> mockedCauseList;
 
     /**
      * Common stuff to set up for the tests.
      */
     @Before
     public void setUp() {
-        indications = new LinkedList<Indication>();
-        indication = new BuildLogIndication("something");
+        List<Indication> indications = new LinkedList<>();
+        Indication indication = new BuildLogIndication("something");
         indications.add(indication);
         mockedCause = new FailureCause("id", "myFailureCause", "description", "comment", new Date(),
                 "category", indications, null);
+        mockedCauseList = new ArrayList<>(Arrays.asList(mockedCause, mockedCause));
 
         PowerMockito.mockStatic(Metrics.class);
         PowerMockito.when(Metrics.metricRegistry()).thenReturn(metricRegistry);
@@ -62,6 +65,7 @@ public class MetricsManagerTest {
     /**
      * Test that the case and category counters are created from a FailureCause.
      */
+    @Test
     public void testAddMetric() {
         addMetric(mockedCause);
 
@@ -70,13 +74,23 @@ public class MetricsManagerTest {
     }
 
     /**
-     * Test that the cause and category counters are incremented for a Failurecasue.
+     * Test that the cause and category counters are incremented twice for a FailureCause when not using squashing.
      */
-    public void testIncCounters() {
-        incCounters(mockedCause);
+    @Test
+    public void testIncCountersWithSquashingDisabled() {
+        incCounters(mockedCauseList, false);
 
-        verify(metricRegistry, times(1)).counter("jenkins_bfa.cause.myFailureCause").inc();
-        verify(metricRegistry, times(1)).counter("jenkins_bfa.category.category").inc();
+        verify(counter, times(mockedCauseList.size() * 2)).inc();
+    }
+
+    /**
+     * Test that the cause and category counters are incremented once for a FailureCause when using squashing.
+     */
+    @Test
+    public void testIncCountersWithSquashingEnabled() {
+        incCounters(mockedCauseList, true);
+
+        verify(counter, times(mockedCauseList.size())).inc();
     }
 
 }

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/PluginImplHudsonTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/PluginImplHudsonTest.java
@@ -99,6 +99,7 @@ public class PluginImplHudsonTest {
         assertFalse("doNotAnalyzeAbortedJob: default value is false", instance.isDoNotAnalyzeAbortedJob());
         assertFalse("graphsEnabled: default value is false", instance.isGraphsEnabled());
         assertTrue("noCausesEnabled: default value is true", instance.isNoCausesEnabled());
+        assertFalse("metricSquashingEnabled: default value is false", instance.isMetricSquashingEnabled());
         // to ever get graphsEnabled, we'll need a KB with enableStatistics, like MongoDBKB with the right option
         MongoDBKnowledgeBase mongoKB = new MongoDBKnowledgeBase("host", 27017, "dbname", "username",
                 Secret.fromString("password"), true, true);
@@ -116,6 +117,7 @@ public class PluginImplHudsonTest {
         form.put("doNotAnalyzeAbortedJob", !instance.isDoNotAnalyzeAbortedJob());
         form.put("graphsEnabled", !instance.isGraphsEnabled());
         form.put("noCausesEnabled", !instance.isNoCausesEnabled());
+        form.put("metricSquashingEnabled", !instance.isMetricSquashingEnabled());
         instance.configure(sreq, form);
         // assert opposite config
         assertFalse("globalEnabled: opposite value is false", instance.isGlobalEnabled());
@@ -124,6 +126,7 @@ public class PluginImplHudsonTest {
         assertTrue("doNotAnalyzeAbortedJob: opposite value is true", instance.isDoNotAnalyzeAbortedJob());
         assertTrue("graphsEnabled: opposite value is true", instance.isGraphsEnabled());
         assertFalse("noCausesEnabled: opposite value is false", instance.isNoCausesEnabled());
+        assertTrue("metricSquashingEnabled: opposite value is true", instance.isMetricSquashingEnabled());
     }
 
     /**
@@ -336,6 +339,7 @@ public class PluginImplHudsonTest {
         form.put("slackFailureCategories", PluginImpl.DEFAULT_SLACK_FAILURE_CATEGORIES);
         form.put("testResultParsingEnabled", true);
         form.put("testResultCategories", "foo bar");
+        form.put("metricSquashingEnabled", false);
         form.put("knowledgeBase", new JSONObject());
         form.put("nrOfScanThreads", nrOfScanThreads);
         form.put("maximumNumberOfWorkerThreads", ScanOnDemandVariables.DEFAULT_MAXIMUM_SOD_WORKER_THREADS);

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/jcasc/ConfigurationAsCodeLocalTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/jcasc/ConfigurationAsCodeLocalTest.java
@@ -65,6 +65,8 @@ public class ConfigurationAsCodeLocalTest {
 
         assertThat(plugin.getTestResultCategories(), is("hgjghhlllllaa"));
         assertThat(plugin.isTestResultParsingEnabled(), is(true));
+
+        assertThat(plugin.isMetricSquashingEnabled(), is(false));
     }
 
     /**

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/jcasc/ConfigurationAsCodeMongoTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/jcasc/ConfigurationAsCodeMongoTest.java
@@ -69,6 +69,8 @@ public class ConfigurationAsCodeMongoTest {
 
         assertThat(plugin.getTestResultCategories(), is("hgjghhlllllaa"));
         assertThat(plugin.isTestResultParsingEnabled(), is(true));
+
+        assertThat(plugin.isMetricSquashingEnabled(), is(false));
     }
 
     /**

--- a/src/test/resources/com/sonyericsson/jenkins/plugins/bfa/jcasc/jcasc-local-expected.yml
+++ b/src/test/resources/com/sonyericsson/jenkins/plugins/bfa/jcasc/jcasc-local-expected.yml
@@ -4,6 +4,7 @@ globalEnabled: true
 graphsEnabled: false
 knowledgeBase: "localFile"
 maxLogSize: 10
+metricSquashingEnabled: false
 noCausesEnabled: true
 noCausesMessage: "No problems were identified. Please contribute  causes to help others"
 nrOfScanThreads: 6

--- a/src/test/resources/com/sonyericsson/jenkins/plugins/bfa/jcasc/jcasc-local.yml
+++ b/src/test/resources/com/sonyericsson/jenkins/plugins/bfa/jcasc/jcasc-local.yml
@@ -6,6 +6,7 @@ unclassified:
     graphsEnabled: false
     knowledgeBase: "localFile"
     maxLogSize: 10
+    metricSquashingEnabled: false
     noCausesEnabled: true
     noCausesMessage: "No problems were identified. Please contribute  causes to help others"
     nrOfScanThreads: 6

--- a/src/test/resources/com/sonyericsson/jenkins/plugins/bfa/jcasc/jcasc-mongo-expected.yml
+++ b/src/test/resources/com/sonyericsson/jenkins/plugins/bfa/jcasc/jcasc-mongo-expected.yml
@@ -12,6 +12,7 @@ knowledgeBase:
     successfulLogging: false
     userName: "bfa"
 maxLogSize: 10
+metricSquashingEnabled: false
 noCausesEnabled: true
 noCausesMessage: "No problems were identified. Please contribute  causes to help others"
 nrOfScanThreads: 6

--- a/src/test/resources/com/sonyericsson/jenkins/plugins/bfa/jcasc/jcasc-mongo.yml
+++ b/src/test/resources/com/sonyericsson/jenkins/plugins/bfa/jcasc/jcasc-mongo.yml
@@ -14,6 +14,7 @@ unclassified:
         port: 27017
         successfulLogging: false
     maxLogSize: 10
+    metricSquashingEnabled: false
     noCausesEnabled: true
     noCausesMessage: "No problems were identified. Please contribute  causes to help others"
     nrOfScanThreads: 6


### PR DESCRIPTION
"Squash failure metrics to unique categories for each build" option can be useful when a single failed build should count towards each cause category exactly once. 

This is particularly useful when combined with the "Treat failed  test cases as failure causes." If numerous tests fail, "squash failure metrics" will prevent those categories from being incremented for every single failed test, which can skew metrics significantly.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue