### PR TITLE
JENKINS-67238 ensure that we can retrieve causes and categories before the updater has run.

### DIFF
--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/db/MongoDBKnowledgeBaseCacheTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/db/MongoDBKnowledgeBaseCacheTest.java
@@ -32,6 +32,8 @@ import com.sonyericsson.jenkins.plugins.bfa.model.FailureCause;
 import org.bson.conversions.Bson;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 import org.mongojack.JacksonMongoCollection;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -64,13 +66,27 @@ public class MongoDBKnowledgeBaseCacheTest {
     public void testStartStop() throws Exception {
         FailureCause mockedCause =
                 new FailureCause("id", "myFailureCause", "description", "comment", null, "category", null, null);
-        FindIterable<FailureCause> iterable = mock(FindIterable.class);
-        MongoCursor<FailureCause> cursor = mock(MongoCursor.class);
-        when(iterable.iterator()).thenReturn(cursor);
-        when(cursor.next()).thenReturn(mockedCause);
-        when(cursor.hasNext()).thenReturn(true, false);
         JacksonMongoCollection<FailureCause> collection = mock(JacksonMongoCollection.class);
+        FindIterable<FailureCause> iterable = mock(FindIterable.class);
+        when(iterable.iterator()).thenAnswer(new Answer<MongoCursor<FailureCause>>() {
+            public MongoCursor<FailureCause>answer(InvocationOnMock invocation) {
+                MongoCursor<FailureCause> cursor = mock(MongoCursor.class);
+                when(cursor.next()).thenReturn(mockedCause);
+                when(cursor.hasNext()).thenReturn(true, false);
+                return cursor;
+            }
+        });
         doReturn(iterable).when(collection).find(any(Bson.class));
+        DistinctIterable<String> categoriesIterable = mock(DistinctIterable.class);
+        when(categoriesIterable.iterator()).thenAnswer(new Answer<MongoCursor<String>>() {
+            public MongoCursor<String>answer(InvocationOnMock invocation) {
+                MongoCursor<String> categoriesCursor = mock(MongoCursor.class);
+                when(categoriesCursor.next()).thenReturn("test");
+                when(categoriesCursor.hasNext()).thenReturn(true, false);
+                return categoriesCursor;
+            }
+        });
+        doReturn(categoriesIterable).when(collection).distinct("categories", String.class);
         MongoDBKnowledgeBaseCache cache = new MongoDBKnowledgeBaseCache(collection);
         cache.start();
         while (cache.getCauses() == null) {


### PR DESCRIPTION
See https://issues.jenkins.io/browse/JENKINS-67238

This ensures that even before the Mongo KnowledgeBase is started that calls to get the causes and categories will not NullPointer.

Ideally the starting of new knowledge bases set through casc should also be addressed. However this is problematic in terms of maintaining the current functionality.

With casc the setKnowledgeBase method on the plugin is called to swap the knowledge bases. However a lot of functionality is coded in the configure method which is called when a UI config update has occurred. Attempting to move the code to start new knowledge bases into the code that is called when casc is used to update causes a lot of test failures. It is difficult to maintain the reverting to the previous knowledge base when the new one fails to start whilst moving code into the location that is common to both sources of configuration update.
 
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
