### PR TITLE
Increase visibility of exported Failure Cause methods

### DIFF
--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -12,4 +12,5 @@
     <suppress checks=".+"
               files="InjectedTest.java"/>
     <suppress checks="MagicNumber" files="BuildLogIndication.java"/>
+    <suppress checks="MagicNumber" files="FoundFailureCause.java"/>
 </suppressions>

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCauseBuildAction.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCauseBuildAction.java
@@ -100,7 +100,7 @@ public class FailureCauseBuildAction implements BuildBadgeAction {
      *
      * @return the FoundFailureCauses.
      */
-    @Exported
+    @Exported(visibility = 2)
     public List<FoundFailureCause> getFoundFailureCauses() {
         return foundFailureCauses;
     }
@@ -205,7 +205,7 @@ public class FailureCauseBuildAction implements BuildBadgeAction {
      *
      * @return the FailureCauseDisplayData.
      */
-    @Exported
+    @Exported(visibility = 2)
     public FailureCauseDisplayData getFailureCauseDisplayData() {
         FailureCauseDisplayData failureCauseDisplayData
                 = getDownstreamData(this, 0);

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FoundFailureCause.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FoundFailureCause.java
@@ -83,7 +83,7 @@ public class FoundFailureCause implements IFailureCauseMetricData {
      *
      * @return the id.
      */
-    @Exported
+    @Exported(visibility = 3)
     public String getId() {
         return id;
     }
@@ -93,7 +93,7 @@ public class FoundFailureCause implements IFailureCauseMetricData {
      *
      * @return the name.
      */
-    @Exported
+    @Exported(visibility = 3)
     public String getName() {
         return name;
     }
@@ -103,7 +103,7 @@ public class FoundFailureCause implements IFailureCauseMetricData {
      *
      * @return the description.
      */
-    @Exported
+    @Exported(visibility = 3)
     public String getDescription() {
         return description;
     }
@@ -113,7 +113,7 @@ public class FoundFailureCause implements IFailureCauseMetricData {
      *
      * @return the categories.
      */
-    @Exported
+    @Exported(visibility = 3)
     public List<String> getCategories() {
         return categories;
     }


### PR DESCRIPTION
Increase the visibility of `FailureCauseBuildAction` and `FoundFailureCause` methods so they are visible in the REST API.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
