### PR TITLE
Adapt icon removal from core

### DIFF
--- a/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/CauseManagement/index.groovy
+++ b/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/CauseManagement/index.groovy
@@ -159,7 +159,7 @@ l.layout(norefresh: true) {
           td {
             if (canRemove) {
               a(href: "remove?id=" + cause.getId(), title:_("Remove")) {
-                img(src: imagesURL + "/16x16/edit-delete.png", alt: _("Remove"))
+                l.task(icon: "icon-edit-delete icon-sm", alt: _("Remove"))
               }
             }
           }


### PR DESCRIPTION
The change proposed prepares the plugin for the icon path removal from core in the upcoming LTS line. This change affects plugins not using the icon API or relying on paths. Plugins using the API properly in the first place are unaffected by this change.

Could you trigger a release after merging this PR please, giving people a chance to update the plugin before updating to the next LTS version @rsandell 
Thanks in advance!