### PR TITLE
Added multi node support for MongoDB

### DIFF
--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/db/MongoDBKnowledgeBase.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/db/MongoDBKnowledgeBase.java
@@ -709,17 +709,23 @@ public class MongoDBKnowledgeBase extends KnowledgeBase {
      * Gets the connection to the MongoDB
      * @return the Mongo.
      */
-    private MongoClient getMongoConnection() {
+    MongoClient getMongoConnection() {
         if (mongo == null) {
             StringBuilder connectionStringBuilder = new StringBuilder(host);
             connectionStringBuilder.append(":").append(port);
             MongoClientSettings.Builder builder = MongoClientSettings.builder().applyToClusterSettings(
                     builder1 -> {
-                        List<ServerAddress> hostlist = new LinkedList<ServerAddress>();
-                        hostlist.add(new ServerAddress(host, port));
+                        List<ServerAddress> hostlist = new LinkedList<>();
+                        for (String h: host.split(",")) {
+                            hostlist.add(new ServerAddress(h, port));
+                        }
+                        //CS IGNORE AvoidInlineConditionals FOR NEXT 3 LINES. REASON: Split up makes code less readable.
+                        ClusterConnectionMode mode = hostlist.size() > 1
+                                ? ClusterConnectionMode.MULTIPLE
+                                : ClusterConnectionMode.SINGLE;
                         builder1.hosts(hostlist).
                                 serverSelectionTimeout(SERVER_SELECTION_TIMEOUT, TimeUnit.MILLISECONDS).
-                                mode(ClusterConnectionMode.SINGLE);
+                                mode(mode);
                     }).applyToConnectionPoolSettings(builder15 -> {
 
                     }).applyToServerSettings(builder12 -> {

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/db/MongoDBKnowledgeBaseTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/db/MongoDBKnowledgeBaseTest.java
@@ -28,8 +28,10 @@ import com.codahale.metrics.MetricRegistry;
 import com.mongodb.DBObject;
 import com.mongodb.MongoException;
 import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCursor;
 import com.mongodb.client.result.UpdateResult;
+import com.mongodb.connection.ClusterConnectionMode;
 import com.sonyericsson.jenkins.plugins.bfa.model.FailureCause;
 import com.sonyericsson.jenkins.plugins.bfa.model.indication.BuildLogIndication;
 import com.sonyericsson.jenkins.plugins.bfa.model.indication.Indication;
@@ -117,6 +119,23 @@ public class MongoDBKnowledgeBaseTest {
     public void tearDown() {
         jenkinsMockedStatic.close();
         metricsMockedStatic.close();
+    }
+
+    /**
+     * Tests that the cluster connection mode is set correctly for each kind of input.
+     *
+     * @throws Exception if so.
+     */
+    @Test
+    public void testClusterModes() throws Exception {
+        MongoDBKnowledgeBase singleNodekb = new MongoDBKnowledgeBase("oneNode", PORT, "mydb", null, null, false, false);
+        MongoDBKnowledgeBase multiNodekb = new MongoDBKnowledgeBase("node1,node2,node3", PORT, "mydb", null, null, false, false);
+        MongoClient mongo = singleNodekb.getMongoConnection();
+        ClusterConnectionMode connectionMode = mongo.getClusterDescription().getConnectionMode();
+        assertSame(connectionMode, ClusterConnectionMode.SINGLE);
+        mongo = multiNodekb.getMongoConnection();
+        connectionMode = mongo.getClusterDescription().getConnectionMode();
+        assertSame(connectionMode, ClusterConnectionMode.MULTIPLE);
     }
 
     /**

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/db/MongoDBKnowledgeBaseTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/db/MongoDBKnowledgeBaseTest.java
@@ -128,8 +128,10 @@ public class MongoDBKnowledgeBaseTest {
      */
     @Test
     public void testClusterModes() throws Exception {
-        MongoDBKnowledgeBase singleNodekb = new MongoDBKnowledgeBase("oneNode", PORT, "mydb", null, null, false, false);
-        MongoDBKnowledgeBase multiNodekb = new MongoDBKnowledgeBase("node1,node2,node3", PORT, "mydb", null, null, false, false);
+        MongoDBKnowledgeBase singleNodekb = new MongoDBKnowledgeBase(
+                "oneNode", PORT, "mydb", null, null, false, false);
+        MongoDBKnowledgeBase multiNodekb = new MongoDBKnowledgeBase(
+                "node1,node2,node3", PORT, "mydb", null, null, false, false);
         MongoClient mongo = singleNodekb.getMongoConnection();
         ClusterConnectionMode connectionMode = mongo.getClusterDescription().getConnectionMode();
         assertSame(connectionMode, ClusterConnectionMode.SINGLE);


### PR DESCRIPTION
The host setting can now be input as a list of hosts, separated
by a comma. For everyone just inputting one host, there is no change
in functionality.
Made getMongoConnection in MongoDBKnowledgeBase package-private for
testing purposes.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
