### PR TITLE
Fix ScanOnDemandVariables for Java 11 ThreadPoolExecutor.

### DIFF
--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/sod/ScanOnDemandVariables.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/sod/ScanOnDemandVariables.java
@@ -126,11 +126,8 @@ public class ScanOnDemandVariables extends AbstractDescribableImpl<ScanOnDemandV
      * @return int value.
      */
      public int getSodCorePoolNumberOfThreads() {
-         if (sodCorePoolNumberOfThreads < ScanOnDemandVariables.DEFAULT_SOD_COREPOOL_THREADS) {
-             return ScanOnDemandVariables.DEFAULT_SOD_COREPOOL_THREADS;
-         }
-
-         return sodCorePoolNumberOfThreads;
+         return Math.min(Math.max(sodCorePoolNumberOfThreads, ScanOnDemandVariables.DEFAULT_SOD_COREPOOL_THREADS),
+                 getMaximumSodWorkerThreads());
      }
 
     /**

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/jcasc/ConfigurationAsCodeLocalTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/jcasc/ConfigurationAsCodeLocalTest.java
@@ -25,7 +25,7 @@ public class ConfigurationAsCodeLocalTest {
 
     static final String NO_CAUSES_MESSAGE = "No problems were identified. Please contribute  causes to help others";
     static final int EXPECTED_SCAN_THREADS = 6;
-    static final int EXPECTED_MAXIMUM_SOD_WORKER_THREADS = 4;
+    static final int EXPECTED_MAXIMUM_SOD_WORKER_THREADS = 7;
     static final int EXPECTED_MINIMUM_SOD_WORKER_THREADS = 2;
     static final int EXPECTED_SOD_CORE_POOL_NUMBER_OF_THREADS = 6;
     static final int EXPECTED_SOD_THREAD_KEEP_ALIVE_TIME = 17;

--- a/src/test/resources/com/sonyericsson/jenkins/plugins/bfa/jcasc/jcasc-local-expected.yml
+++ b/src/test/resources/com/sonyericsson/jenkins/plugins/bfa/jcasc/jcasc-local-expected.yml
@@ -11,7 +11,7 @@ nrOfScanThreads: 6
 slackFailureCategories: "ALL"
 slackNotifEnabled: false
 sodVariables:
-  maximumSodWorkerThreads: 4
+  maximumSodWorkerThreads: 7
   minimumSodWorkerThreads: 2
   sodCorePoolNumberOfThreads: 6
   sodThreadKeepAliveTime: 17

--- a/src/test/resources/com/sonyericsson/jenkins/plugins/bfa/jcasc/jcasc-local.yml
+++ b/src/test/resources/com/sonyericsson/jenkins/plugins/bfa/jcasc/jcasc-local.yml
@@ -12,7 +12,7 @@ unclassified:
     nrOfScanThreads: 6
     slackNotifEnabled: false
     sodVariables:
-      maximumSodWorkerThreads: 4
+      maximumSodWorkerThreads: 7
       minimumSodWorkerThreads: 2
       sodCorePoolNumberOfThreads: 6
       sodThreadKeepAliveTime: 17

--- a/src/test/resources/com/sonyericsson/jenkins/plugins/bfa/jcasc/jcasc-mongo-expected.yml
+++ b/src/test/resources/com/sonyericsson/jenkins/plugins/bfa/jcasc/jcasc-mongo-expected.yml
@@ -19,7 +19,7 @@ nrOfScanThreads: 6
 slackFailureCategories: "ALL"
 slackNotifEnabled: false
 sodVariables:
-  maximumSodWorkerThreads: 4
+  maximumSodWorkerThreads: 7
   minimumSodWorkerThreads: 2
   sodCorePoolNumberOfThreads: 6
   sodThreadKeepAliveTime: 17

--- a/src/test/resources/com/sonyericsson/jenkins/plugins/bfa/jcasc/jcasc-mongo.yml
+++ b/src/test/resources/com/sonyericsson/jenkins/plugins/bfa/jcasc/jcasc-mongo.yml
@@ -20,7 +20,7 @@ unclassified:
     nrOfScanThreads: 6
     slackNotifEnabled: false
     sodVariables:
-      maximumSodWorkerThreads: 4
+      maximumSodWorkerThreads: 7
       minimumSodWorkerThreads: 2
       sodCorePoolNumberOfThreads: 6
       sodThreadKeepAliveTime: 17


### PR DESCRIPTION
As shown in JENKINS-70489, an IllegalArgumentError is thrown when scanning builds on demand.
This is because the Java 11 version of ThreadPoolExecutor is more picky with input values, making sure that corePoolSize < maximumPoolSize. This commit fixes our input values to make sure the above is true.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
