### PR TITLE
Fix for leaking threads when closing a MongoDBKnowledgeBase

### DIFF
--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/db/MongoDBKnowledgeBase.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/db/MongoDBKnowledgeBase.java
@@ -238,6 +238,7 @@ public class MongoDBKnowledgeBase extends KnowledgeBase {
         }
         if (mongo != null) {
             mongo.close();
+            mongo = null;
         }
     }
 

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/db/MongoDBKnowledgeBase.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/db/MongoDBKnowledgeBase.java
@@ -236,6 +236,9 @@ public class MongoDBKnowledgeBase extends KnowledgeBase {
             cache.stop();
             cache = null;
         }
+        if (mongo != null) {
+            mongo.close();
+        }
     }
 
     /**
@@ -881,6 +884,8 @@ public class MongoDBKnowledgeBase extends KnowledgeBase {
                 base.getDb().runCommand(ping);
             } catch (Exception e) {
                 return FormValidation.error(e, Messages.MongoDBKnowledgeBase_ConnectionError());
+            } finally {
+                base.stop();
             }
             return FormValidation.ok(Messages.MongoDBKnowledgeBase_ConnectionOK());
         }

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/db/MongoDBKnowledgeBaseTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/db/MongoDBKnowledgeBaseTest.java
@@ -55,6 +55,7 @@ import java.util.List;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertSame;
 import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -223,5 +224,15 @@ public class MongoDBKnowledgeBaseTest {
     public void testThrowMongo() throws Exception {
         when(collection.find(ArgumentMatchers.<Bson>any())).thenThrow(MongoException.class);
         kb.getCauseNames();
+    }
+
+    /**
+     * Tests that the MongoConnection of the KnowledgeBase is set to null after stop is run.
+     */
+    @Test
+    public void testStopKnowledgeBase() {
+        kb.getMongoConnection();
+        kb.stop();
+        assertNull("MongoConnection should be null", Whitebox.getInternalState(kb, "mongo"));
     }
 }


### PR DESCRIPTION
Either when you click the "Test Connection" button, or switch from a MongoDBKnowledgeBase, connection threads towards the old one are left hanging around. These won't get removed until the Jenkins server is restarted.

This commit makes sure that the connection is closed, which also remove the threads.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
