### PR TITLE
Add line matching for multi-line pattern parse

### DIFF
--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureReader.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureReader.java
@@ -35,6 +35,7 @@ import hudson.model.Run;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.LineNumberReader;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -318,7 +319,7 @@ public abstract class FailureReader {
      * @return a FoundIndication if we find the pattern, null if not.
      * @throws IOException if problems occur in the reader handling.
      */
-    protected FoundIndication scanMultiLineOneFile(Run build, BufferedReader reader, String currentFile)
+    protected FoundIndication scanMultiLineOneFile(Run build, LineNumberReader reader, String currentFile)
             throws IOException {
         TimerThread timerThread = new TimerThread(Thread.currentThread(), TIMEOUT_BLOCK);
         FoundIndication foundIndication = null;
@@ -338,7 +339,7 @@ public abstract class FailureReader {
                     Matcher matcher = pattern.matcher(new InterruptibleCharSequence(searchBuffer.toString()));
                     if (matcher.find()) {
                         foundIndication = new FoundIndication(build, pattern.pattern(), currentFile,
-                                removeConsoleNotes(matcher.group()), -1);
+                                removeConsoleNotes(matcher.group()), reader.getLineNumber());
                         break;
                     }
                     searchBuffer.delete(0, BUF_SIZE_BYTES - OVERLAP_BYTES);

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/MultilineBuildLogFailureReader.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/MultilineBuildLogFailureReader.java
@@ -24,8 +24,8 @@
 
 package com.sonyericsson.jenkins.plugins.bfa.model;
 
-import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.LineNumberReader;
 import java.io.PrintStream;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -62,9 +62,9 @@ public class MultilineBuildLogFailureReader extends FailureReader {
      */
     @Override
     public FoundIndication scan(Run build) throws IOException {
-        BufferedReader reader = null;
+        LineNumberReader reader = null;
         try {
-            reader = new BufferedReader(build.getLogReader());
+            reader = new LineNumberReader(build.getLogReader());
             return scanMultiLineOneFile(build, reader, "log");
         } finally {
             if (reader != null) {
@@ -88,10 +88,10 @@ public class MultilineBuildLogFailureReader extends FailureReader {
      */
     public FoundIndication scan(Run build, PrintStream buildLog) {
         FoundIndication foundIndication = null;
-        BufferedReader reader = null;
+        LineNumberReader reader = null;
         long start = System.currentTimeMillis();
         try {
-            reader = new BufferedReader(build.getLogReader());
+            reader = new LineNumberReader(build.getLogReader());
             foundIndication = scanMultiLineOneFile(build, reader, "log");
         } catch (IOException ioe) {
             logger.log(Level.SEVERE, "[BFA] I/O problems during indication analysis: ", ioe);


### PR DESCRIPTION
Changed the reader for multli-line pattern scan from BufferedReader to **LineNumberReader** which is a subclass of BufferedReader that adds the feature of counting lines for all read operations, which can then be used to **set matching line for the found indication**.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
