### PR TITLE
Forward compatibility with recent versions of HtmlUnit

### DIFF
--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCauseHudsonTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCauseHudsonTest.java
@@ -24,7 +24,7 @@
 
 package com.sonyericsson.jenkins.plugins.bfa.model;
 
-import org.htmlunit.NicelyResynchronizingAjaxController;
+import org.htmlunit.WebClientUtil;
 import org.htmlunit.WebResponse;
 import org.htmlunit.WebResponseListener;
 import org.htmlunit.html.HtmlInput;
@@ -157,7 +157,6 @@ public class FailureCauseHudsonTest {
     @Test
     public void testDoCheckNameViaWebForm() throws Exception {
         JenkinsRule.WebClient client = jenkins.createWebClient();
-        client.setAjaxController(new NicelyResynchronizingAjaxController());
 
         WebResponseListener.StatusListener serverErrors =
                 new WebResponseListener.StatusListener(HttpStatus.SC_INTERNAL_SERVER_ERROR);
@@ -172,6 +171,7 @@ public class FailureCauseHudsonTest {
         HtmlInput input = page.getFormByName("causeForm").getInputByName("_.name");
         input.setValue("Mööp");
         input.fireEvent("change");
+        WebClientUtil.waitForJSExec(page.getWebClient());
 
         assertTrue(serverErrors.getResponses().isEmpty());
         WebResponse webResponse = success.getResponses().get(success.getResponses().size() - 1);
@@ -189,7 +189,6 @@ public class FailureCauseHudsonTest {
     @Test
     public void testDoCheckDescriptionViaWebForm() throws Exception {
         JenkinsRule.WebClient client = jenkins.createWebClient();
-        client.setAjaxController(new NicelyResynchronizingAjaxController());
 
         WebResponseListener.StatusListener serverErrors =
                 new WebResponseListener.StatusListener(HttpStatus.SC_INTERNAL_SERVER_ERROR);
@@ -204,6 +203,7 @@ public class FailureCauseHudsonTest {
         HtmlTextArea input = page.getFormByName("causeForm").getTextAreaByName("_.description");
         input.setText("Mööp");
         input.fireEvent("change");
+        WebClientUtil.waitForJSExec(page.getWebClient());
 
         assertTrue(serverErrors.getResponses().isEmpty());
         WebResponse webResponse = success.getResponses().get(success.getResponses().size() - 1);


### PR DESCRIPTION
When attempting to add this plugin to `jenkinsci/bom` (since it is a dependency of 4 other Jenkins plugins), I found that these two tests failed to run in recent versions of HtmlUnit. The problem seems to be related to `NicelyResynchronizingAjaxController`, as I no longer experienced any issues with the default `AjaxController`. Since JavaScript is now running asynchronously, I added a barrier to ensure that asynchronous activity is complete by the time we make the assertions.

### Testing done

Tested before and after the upgrade to the latest HtmlUnit. Before, the tests only passed on the old version of HtmlUnit. After, they pass on both old and new versions of HtmlUnit.