### PR TITLE
Require Java 17 and 2.475; adapt test suite to EE 9

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,3 @@
 buildPlugin(useContainerAgent: true, configurations: [
-  [ platform: 'linux', jdk: '11' ],
+  [ platform: 'linux', jdk: '17' ],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,10 @@
     <properties>
         <revision>2.5.3</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.375.3</jenkins.version>
+        <jenkins.version>2.475</jenkins.version>
+        <!-- TODO JENKINS-73339 until in parent POM -->
+        <jenkins-test-harness.version>2254.vcff7a_d4969e5</jenkins-test-harness.version>
+        <maven.compiler.release>17</maven.compiler.release>
         <checkstyle.version>3.1.1</checkstyle.version>
         <no-test-jar>false</no-test-jar>
     </properties>
@@ -210,7 +213,6 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>parameterized-trigger</artifactId>
             <scope>test</scope>
-            <version>2.45</version>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -277,17 +279,22 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>metrics</artifactId>
-            <version>4.2.18-439.v86a_20b_a_8318b_</version>
         </dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.375.x</artifactId>
-                <version>2179.v0884e842b_859</version>
+                <artifactId>bom-2.462.x</artifactId>
+                <version>3234.v5ca_5154341ef</version>
                 <scope>import</scope>
                 <type>pom</type>
+            </dependency>
+            <!-- TODO JENKINS-73339 until in parent POM, work around https://github.com/jenkinsci/plugin-pom/issues/936 -->
+            <dependency>
+                <groupId>jakarta.servlet</groupId>
+                <artifactId>jakarta.servlet-api</artifactId>
+                <version>5.0.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/CauseManagement.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/CauseManagement.java
@@ -42,8 +42,8 @@ import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.Stapler;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 import org.kohsuke.stapler.verb.POST;
 import java.io.IOException;
 
@@ -65,7 +65,7 @@ public class CauseManagement implements RootAction {
     public static final String URL_NAME = "failure-cause-management";
     /**
      * The reserved id for getting a new {@link FailureCause} from {@link #getDynamic(String,
-     * org.kohsuke.stapler.StaplerRequest, org.kohsuke.stapler.StaplerResponse)}.
+     * org.kohsuke.stapler.StaplerRequest2, org.kohsuke.stapler.StaplerResponse2)}.
      */
     public static final String NEW_CAUSE_DYNAMIC_ID = "new";
     /**
@@ -167,11 +167,11 @@ public class CauseManagement implements RootAction {
      * Sets an error message as an attribute to the current request.
      *
      * @param message the message to set.
-     * @see #getErrorMessage(org.kohsuke.stapler.StaplerRequest)
+     * @see #getErrorMessage(org.kohsuke.stapler.StaplerRequest2)
      * @see #REQUEST_CAUSE_MANAGEMENT_ERROR
      */
     private void setErrorMessage(String message) {
-        Stapler.getCurrentRequest().setAttribute(REQUEST_CAUSE_MANAGEMENT_ERROR, message);
+        Stapler.getCurrentRequest2().setAttribute(REQUEST_CAUSE_MANAGEMENT_ERROR, message);
     }
 
     /**
@@ -180,7 +180,7 @@ public class CauseManagement implements RootAction {
      * @param request the request where the message might be.
      * @return true if there is an error message to display.
      */
-    public boolean isError(StaplerRequest request) {
+    public boolean isError(StaplerRequest2 request) {
         return Util.fixEmpty((String)request.getAttribute(REQUEST_CAUSE_MANAGEMENT_ERROR)) != null;
     }
 
@@ -190,7 +190,7 @@ public class CauseManagement implements RootAction {
      * @param request the request where the message might be.
      * @return the error message to show.
      */
-    public String getErrorMessage(StaplerRequest request) {
+    public String getErrorMessage(StaplerRequest2 request) {
         return (String)request.getAttribute(REQUEST_CAUSE_MANAGEMENT_ERROR);
     }
 
@@ -205,7 +205,7 @@ public class CauseManagement implements RootAction {
      *
      * @throws Exception if communication with the knowledge base failed.
      */
-    public FailureCause getDynamic(String id, StaplerRequest request, StaplerResponse response) throws Exception {
+    public FailureCause getDynamic(String id, StaplerRequest2 request, StaplerResponse2 response) throws Exception {
         if (NEW_CAUSE_DYNAMIC_ID.equalsIgnoreCase(id)) {
             return new FailureCause(NEW_CAUSE_NAME, NEW_CAUSE_DESCRIPTION);
         } else {
@@ -222,7 +222,7 @@ public class CauseManagement implements RootAction {
      * @throws IOException if so during redirect.
      */
     @POST
-    public void doRemoveConfirm(@QueryParameter String id, StaplerRequest request, StaplerResponse response)
+    public void doRemoveConfirm(@QueryParameter String id, StaplerRequest2 request, StaplerResponse2 response)
             throws IOException {
         Jenkins.getInstance().checkPermission(PluginImpl.REMOVE_PERMISSION);
         id = Util.fixEmpty(id);

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCause.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCause.java
@@ -48,8 +48,8 @@ import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.Stapler;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 import org.mongojack.Id;
 import org.mongojack.ObjectId;
@@ -245,7 +245,7 @@ public class FailureCause implements Serializable, Action, Describable<FailureCa
      * @param response the response
      * @throws Exception if it fails to save to the knowledge base or a validation error occurs.
      */
-    public synchronized void doConfigSubmit(StaplerRequest request, StaplerResponse response)
+    public synchronized void doConfigSubmit(StaplerRequest2 request, StaplerResponse2 response)
             throws Exception {
         logger.entering(getClass().getName(), "doConfigSubmit");
         Jenkins.getInstance().checkPermission(PluginImpl.UPDATE_PERMISSION);
@@ -560,14 +560,14 @@ public class FailureCause implements Serializable, Action, Describable<FailureCa
     //CS IGNORE JavadocMethod FOR NEXT 8 LINES. REASON: The exception can be thrown.
 
     /**
-     * Finds the {@link CauseManagement} ancestor of the {@link Stapler#getCurrentRequest() current request}.
+     * Finds the {@link CauseManagement} ancestor of the {@link Stapler#getCurrentRequest2() current request}.
      *
      * @return the management action or a derivative of it, or null if no management action is found.
      * @throws IllegalStateException if no ancestor is found.
      */
     @JsonIgnore
     public CauseManagement getAncestorCauseManagement() {
-        StaplerRequest currentRequest = Stapler.getCurrentRequest();
+        StaplerRequest2 currentRequest = Stapler.getCurrentRequest2();
         if (currentRequest == null) {
             return null;
         }
@@ -620,7 +620,7 @@ public class FailureCause implements Serializable, Action, Describable<FailureCa
          * page was entered.
          */
         public String getLastFailedBuildUrl() {
-            StaplerRequest staplerRequest = Stapler.getCurrentRequest();
+            StaplerRequest2 staplerRequest = Stapler.getCurrentRequest2();
             if (staplerRequest != null) {
                 String answer = (String)staplerRequest.getSession(true).
                         getAttribute(LAST_FAILED_BUILD_URL_SESSION_ATTRIBUTE_NAME);
@@ -636,7 +636,7 @@ public class FailureCause implements Serializable, Action, Describable<FailureCa
          * page was entered.
          */
         public void setLastFailedBuildUrl() {
-            StaplerRequest staplerRequest = Stapler.getCurrentRequest();
+            StaplerRequest2 staplerRequest = Stapler.getCurrentRequest2();
             if (staplerRequest != null) {
                 Job project = staplerRequest.findAncestorObject(Job.class);
                 if (project != null && project.getLastFailedBuild() != null) {

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/CauseManagementHudsonTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/CauseManagementHudsonTest.java
@@ -44,10 +44,10 @@ import hudson.model.FreeStyleProject;
 import hudson.util.Secret;
 import org.apache.commons.lang.StringUtils;
 import org.jvnet.hudson.test.HudsonTestCase;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 
-import javax.servlet.http.HttpSession;
+import jakarta.servlet.http.HttpSession;
 import java.text.DateFormat;
 import java.util.Collection;
 import java.util.Collections;
@@ -308,8 +308,8 @@ public class CauseManagementHudsonTest extends HudsonTestCase {
     }
 
     /**
-     * Tests {@link CauseManagement#doRemoveConfirm(String, org.kohsuke.stapler.StaplerRequest,
-     * org.kohsuke.stapler.StaplerResponse)}.
+     * Tests {@link CauseManagement#doRemoveConfirm(String, org.kohsuke.stapler.StaplerRequest2,
+     * org.kohsuke.stapler.StaplerResponse2)}.
      * Assumes that the default {@link com.sonyericsson.jenkins.plugins.bfa.db.LocalFileKnowledgeBase} is used.
      *
      * @throws Exception if so.
@@ -325,10 +325,10 @@ public class CauseManagementHudsonTest extends HudsonTestCase {
         KnowledgeBase kb = spy(PluginImpl.getInstance().getKnowledgeBase());
         Whitebox.setInternalState(PluginImpl.getInstance(), KnowledgeBase.class, kb);
 
-        StaplerRequest request = mock(StaplerRequest.class);
+        StaplerRequest2 request = mock(StaplerRequest2.class);
         HttpSession session = mock(HttpSession.class);
         when(request.getSession(anyBoolean())).thenReturn(session);
-        StaplerResponse response = mock(StaplerResponse.class);
+        StaplerResponse2 response = mock(StaplerResponse2.class);
 
         CauseManagement.getInstance().doRemoveConfirm(cause1.getId(), request, response);
 

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/CauseManagementPermissionTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/CauseManagementPermissionTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
 
 import java.net.URL;
 

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/PluginImplHudsonTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/PluginImplHudsonTest.java
@@ -47,11 +47,11 @@ import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.kohsuke.stapler.RequestImpl;
 import org.kohsuke.stapler.Stapler;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.WebApp;
 
-import javax.servlet.ServletContext;
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.Collections;
 import java.util.List;
 
@@ -104,11 +104,11 @@ public class PluginImplHudsonTest {
         MongoDBKnowledgeBase mongoKB = new MongoDBKnowledgeBase("host", 27017, "dbname", "username",
                 Secret.fromString("password"), true, true);
         instance.setKnowledgeBase(mongoKB);
-        // need an actual StaplerRequest implementation to test we're using bindJSON correctly
+        // need an actual StaplerRequest2 implementation to test we're using bindJSON correctly
         WebApp webapp = new WebApp(mock(ServletContext.class));
         Stapler stapler = mock(Stapler.class);
         when(stapler.getWebApp()).thenReturn(webapp);
-        StaplerRequest sreq = new RequestImpl(stapler, mock(HttpServletRequest.class), Collections.emptyList(), null);
+        StaplerRequest2 sreq = new RequestImpl(stapler, mock(HttpServletRequest.class), Collections.emptyList(), null);
         // flip configuration of all boolean values
         JSONObject form = new JSONObject();
         form.put("globalEnabled", !instance.isGlobalEnabled());
@@ -157,7 +157,7 @@ public class PluginImplHudsonTest {
     }
 
     /**
-     * Tests {@link PluginImpl#configure(org.kohsuke.stapler.StaplerRequest, net.sf.json.JSONObject)}. with a new
+     * Tests {@link PluginImpl#configure(org.kohsuke.stapler.StaplerRequest2, net.sf.json.JSONObject)}. with a new
      * KnowledgeBase type.
      *
      * @throws Exception if so.
@@ -169,7 +169,7 @@ public class PluginImplHudsonTest {
         FailureCause cause = new FailureCause("Olle", "Olle");
         cause.addIndication(new BuildLogIndication(".*olle"));
         cause = prevKnowledgeBase.addCause(cause);
-        StaplerRequest sreq = mock(StaplerRequest.class);
+        StaplerRequest2 sreq = mock(StaplerRequest2.class);
         DifferentKnowledgeBase knowledgeBase = new DifferentKnowledgeBase("Hello");
 
         JSONObject form = createForm("x", PluginImpl.DEFAULT_NR_OF_SCAN_THREADS, true);
@@ -191,7 +191,7 @@ public class PluginImplHudsonTest {
     }
 
     /**
-     * Tests {@link PluginImpl#configure(org.kohsuke.stapler.StaplerRequest, net.sf.json.JSONObject)}. with the same
+     * Tests {@link PluginImpl#configure(org.kohsuke.stapler.StaplerRequest2, net.sf.json.JSONObject)}. with the same
      * KnowledgeBase type but different configuration.
      *
      * @throws Exception if so.
@@ -204,7 +204,7 @@ public class PluginImplHudsonTest {
         cause = prevKnowledgeBase.addCause(cause);
         PluginImpl instance = PluginImpl.getInstance();
         Whitebox.setInternalState(instance, KnowledgeBase.class, prevKnowledgeBase);
-        StaplerRequest sreq = mock(StaplerRequest.class);
+        StaplerRequest2 sreq = mock(StaplerRequest2.class);
         DifferentKnowledgeBase knowledgeBase = new DifferentKnowledgeBase("Hello Again");
         when(sreq.bindJSON(eq(KnowledgeBase.class), isA(JSONObject.class))).thenReturn(knowledgeBase);
 
@@ -228,7 +228,7 @@ public class PluginImplHudsonTest {
     }
 
     /**
-     * Tests {@link PluginImpl#configure(org.kohsuke.stapler.StaplerRequest, net.sf.json.JSONObject)}.
+     * Tests {@link PluginImpl#configure(org.kohsuke.stapler.StaplerRequest2, net.sf.json.JSONObject)}.
      * Tests that a LocalFileKnowledgebase is preserved through a reconfigure without changes.
      *
      * @throws Exception if so.
@@ -254,7 +254,7 @@ public class PluginImplHudsonTest {
     //CS IGNORE MagicNumber FOR NEXT 17 LINES. REASON: Random test data
 
     /**
-     * Tests {@link PluginImpl#configure(org.kohsuke.stapler.StaplerRequest, net.sf.json.JSONObject)}.
+     * Tests {@link PluginImpl#configure(org.kohsuke.stapler.StaplerRequest2, net.sf.json.JSONObject)}.
      * Tests that a MongoDBKnowledgebase is preserved through a reconfigure without changes.
      *
      * @throws Exception if so.

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCauseHudsonTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCauseHudsonTest.java
@@ -24,7 +24,7 @@
 
 package com.sonyericsson.jenkins.plugins.bfa.model;
 
-import org.htmlunit.NicelyResynchronizingAjaxController;
+import org.htmlunit.WebClientUtil;
 import org.htmlunit.WebResponse;
 import org.htmlunit.WebResponseListener;
 import org.htmlunit.html.HtmlInput;
@@ -157,7 +157,6 @@ public class FailureCauseHudsonTest {
     @Test
     public void testDoCheckNameViaWebForm() throws Exception {
         JenkinsRule.WebClient client = jenkins.createWebClient();
-        client.setAjaxController(new NicelyResynchronizingAjaxController());
 
         WebResponseListener.StatusListener serverErrors =
                 new WebResponseListener.StatusListener(HttpStatus.SC_INTERNAL_SERVER_ERROR);
@@ -172,6 +171,7 @@ public class FailureCauseHudsonTest {
         HtmlInput input = page.getFormByName("causeForm").getInputByName("_.name");
         input.setValue("Mööp");
         input.fireEvent("change");
+        WebClientUtil.waitForJSExec(page.getWebClient());
 
         assertTrue(serverErrors.getResponses().isEmpty());
         WebResponse webResponse = success.getResponses().get(success.getResponses().size() - 1);
@@ -189,7 +189,6 @@ public class FailureCauseHudsonTest {
     @Test
     public void testDoCheckDescriptionViaWebForm() throws Exception {
         JenkinsRule.WebClient client = jenkins.createWebClient();
-        client.setAjaxController(new NicelyResynchronizingAjaxController());
 
         WebResponseListener.StatusListener serverErrors =
                 new WebResponseListener.StatusListener(HttpStatus.SC_INTERNAL_SERVER_ERROR);
@@ -204,6 +203,7 @@ public class FailureCauseHudsonTest {
         HtmlTextArea input = page.getFormByName("causeForm").getTextAreaByName("_.description");
         input.setText("Mööp");
         input.fireEvent("change");
+        WebClientUtil.waitForJSExec(page.getWebClient());
 
         assertTrue(serverErrors.getResponses().isEmpty());
         WebResponse webResponse = success.getResponses().get(success.getResponses().size() - 1);

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCauseHudsonTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCauseHudsonTest.java
@@ -67,8 +67,8 @@ public class FailureCauseHudsonTest {
 
 
     /**
-     * Happy test for {@link FailureCause#doConfigSubmit(org.kohsuke.stapler.StaplerRequest,
-     * org.kohsuke.stapler.StaplerResponse)}.
+     * Happy test for {@link FailureCause#doConfigSubmit(org.kohsuke.stapler.StaplerRequest2,
+     * org.kohsuke.stapler.StaplerResponse2)}.
      *
      * @throws Exception if so.
      */
@@ -118,8 +118,8 @@ public class FailureCauseHudsonTest {
     }
 
     /**
-     * Happy test for {@link FailureCause#doConfigSubmit(org.kohsuke.stapler.StaplerRequest,
-     * org.kohsuke.stapler.StaplerResponse)} with only one cause configured.
+     * Happy test for {@link FailureCause#doConfigSubmit(org.kohsuke.stapler.StaplerRequest2,
+     * org.kohsuke.stapler.StaplerResponse2)} with only one cause configured.
      *
      * @throws Exception if so.
      */

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCauseTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCauseTest.java
@@ -40,12 +40,12 @@ import net.sf.json.JSONObject;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 
-import javax.servlet.ServletException;
+import jakarta.servlet.ServletException;
 import java.util.Collections;
 import java.util.Date;
 import java.util.LinkedList;
@@ -325,8 +325,8 @@ public class FailureCauseTest {
     }
 
     /**
-     * Happy test for {@link FailureCause#doConfigSubmit(org.kohsuke.stapler.StaplerRequest,
-     * org.kohsuke.stapler.StaplerResponse)}. Where the intention is to save a new cause.
+     * Happy test for {@link FailureCause#doConfigSubmit(org.kohsuke.stapler.StaplerRequest2,
+     * org.kohsuke.stapler.StaplerResponse2)}. Where the intention is to save a new cause.
      *
      * @throws Exception if so.
      */
@@ -340,9 +340,9 @@ public class FailureCauseTest {
         String comment = "Comment";
         String category = "category";
         String pattern = ".*";
-        StaplerRequest request = mockRequest("", name, description, comment, null, category,
+        StaplerRequest2 request = mockRequest("", name, description, comment, null, category,
                 Collections.singletonList(new BuildLogIndication(pattern)), null);
-        StaplerResponse response = mock(StaplerResponse.class);
+        StaplerResponse2 response = mock(StaplerResponse2.class);
 
         FailureCause cause = new FailureCause(null, CauseManagement.NEW_CAUSE_NAME,
                 CauseManagement.NEW_CAUSE_DESCRIPTION, null, null, category, null, null);
@@ -358,8 +358,8 @@ public class FailureCauseTest {
     }
 
     /**
-     * Happy test for {@link FailureCause#doConfigSubmit(org.kohsuke.stapler.StaplerRequest,
-     * org.kohsuke.stapler.StaplerResponse)}. Where the intention is to save changes to an existing cause.
+     * Happy test for {@link FailureCause#doConfigSubmit(org.kohsuke.stapler.StaplerRequest2,
+     * org.kohsuke.stapler.StaplerResponse2)}. Where the intention is to save changes to an existing cause.
      *
      * @throws Exception if so.
      */
@@ -372,9 +372,9 @@ public class FailureCauseTest {
         String description = "The Description";
         String comment = "New Comment";
         String pattern = ".*";
-        StaplerRequest request = mockRequest(id, name, description, comment, null, "",
+        StaplerRequest2 request = mockRequest(id, name, description, comment, null, "",
                 Collections.singletonList(new BuildLogIndication(pattern)), null);
-        StaplerResponse response = mock(StaplerResponse.class);
+        StaplerResponse2 response = mock(StaplerResponse2.class);
 
         FailureCause cause = new FailureCause("Old Name", "Old Description");
         cause.setId(id);
@@ -390,8 +390,8 @@ public class FailureCauseTest {
     }
 
     /**
-     * Tests {@link FailureCause#doConfigSubmit(org.kohsuke.stapler.StaplerRequest,
-     * org.kohsuke.stapler.StaplerResponse)} with a different id in the form than what the stapler binding says it is.
+     * Tests {@link FailureCause#doConfigSubmit(org.kohsuke.stapler.StaplerRequest2,
+     * org.kohsuke.stapler.StaplerResponse2)} with a different id in the form than what the stapler binding says it is.
      *
      * @throws Exception if so
      */
@@ -405,9 +405,9 @@ public class FailureCauseTest {
         String description = "The Description";
         String comment = "New Comment";
         String pattern = ".*";
-        StaplerRequest request = mockRequest(newId, name, description, comment, null, "",
+        StaplerRequest2 request = mockRequest(newId, name, description, comment, null, "",
                 Collections.singletonList(new BuildLogIndication(pattern)), null);
-        StaplerResponse response = mock(StaplerResponse.class);
+        StaplerResponse2 response = mock(StaplerResponse2.class);
 
         FailureCause cause = new FailureCause("Old Name", "Old Description");
         cause.setId(origId);
@@ -415,8 +415,8 @@ public class FailureCauseTest {
     }
 
     /**
-     * Tests {@link FailureCause#doConfigSubmit(org.kohsuke.stapler.StaplerRequest,
-     * org.kohsuke.stapler.StaplerResponse)} where the form data for id is set when it should not be since it is for a
+     * Tests {@link FailureCause#doConfigSubmit(org.kohsuke.stapler.StaplerRequest2,
+     * org.kohsuke.stapler.StaplerResponse2)} where the form data for id is set when it should not be since it is for a
      * new cause.
      *
      * @throws Exception if so
@@ -431,9 +431,9 @@ public class FailureCauseTest {
         String description = "The Description";
         String comment = "New Comment";
         String pattern = ".*";
-        StaplerRequest request = mockRequest(newId, name, description, comment, null, "",
+        StaplerRequest2 request = mockRequest(newId, name, description, comment, null, "",
                 Collections.singletonList(new BuildLogIndication(pattern)), null);
-        StaplerResponse response = mock(StaplerResponse.class);
+        StaplerResponse2 response = mock(StaplerResponse2.class);
 
         FailureCause cause = new FailureCause("Old Name", "Old Description");
         cause.setId(origId);
@@ -441,8 +441,8 @@ public class FailureCauseTest {
     }
 
     /**
-     * Tests {@link FailureCause#doConfigSubmit(org.kohsuke.stapler.StaplerRequest,
-     * org.kohsuke.stapler.StaplerResponse)} where the form data for id is null when it should be for an existing
+     * Tests {@link FailureCause#doConfigSubmit(org.kohsuke.stapler.StaplerRequest2,
+     * org.kohsuke.stapler.StaplerResponse2)} where the form data for id is null when it should be for an existing
      * cause.
      *
      * @throws Exception if so
@@ -457,9 +457,9 @@ public class FailureCauseTest {
         String description = "New Description";
         String comment = "New Comment";
         String pattern = ".*";
-        StaplerRequest request = mockRequest(newId, name, description, comment, null, "",
+        StaplerRequest2 request = mockRequest(newId, name, description, comment, null, "",
                 Collections.singletonList(new BuildLogIndication(pattern)), null);
-        StaplerResponse response = mock(StaplerResponse.class);
+        StaplerResponse2 response = mock(StaplerResponse2.class);
 
         FailureCause cause = new FailureCause("A Name", "The Description");
         cause.setId(origId);
@@ -476,13 +476,13 @@ public class FailureCauseTest {
      * @param occurred    the time of last occurrence
      * @param category    the category
      * @param indications the list of indications as they should be returned from
-     *                      {@link StaplerRequest#bindJSONToList(Class, Object)}
+     *                      {@link StaplerRequest2#bindJSONToList(Class, Object)}
      * @param modifications the modification history of this FailureCause
      * @return a mocked request object.
      *
      * @throws ServletException if so, but probably not.
      */
-    private StaplerRequest mockRequest(String id, String name, String description, String comment, Date occurred,
+    private StaplerRequest2 mockRequest(String id, String name, String description, String comment, Date occurred,
                                        String category, List<? extends Indication> indications,
                                        List<FailureCauseModification> modifications) throws ServletException {
         JSONObject form = new JSONObject();
@@ -500,7 +500,7 @@ public class FailureCauseTest {
         if (modifications != null) {
             form.put("modifications", modifications);
         }
-        StaplerRequest request = mock(StaplerRequest.class);
+        StaplerRequest2 request = mock(StaplerRequest2.class);
         when(request.getSubmittedForm()).thenReturn(form);
         when(request.bindJSONToList(same(Indication.class), any()))
                 .thenReturn((List<Indication>)indications);


### PR DESCRIPTION
Subsumes #181. Allow this plugin's test suite to be exercised regularly in Plugin Compatibility Tester (PCT) in https://github.com/jenkinsci/bom by requiring Java 17 or newer and Jenkins 2.475 (released today) or newer.

This PR goes against the usual advice from https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ by requiring a weekly release. The advantage is that this will allow plugin compatibility testing (PCT). The disadvantage is that new features and bug fixes can't be released to LTS users for another few months.

The choice is up to the maintainer as to whether or not to accept this PR. If this PR is rejected, we will stop testing this plugin in PCT.