### PR TITLE
Set max pool size before core pool size in BuildFailureScanner#findCa…

### DIFF
--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/BuildFailureScanner.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/BuildFailureScanner.java
@@ -396,8 +396,8 @@ public class BuildFailureScanner extends RunListener<Run> {
      */
     private static List<FoundFailureCause> findCauses(final Collection<FailureCause> causes,
                                                       final Run build, final PrintStream scanLog) {
-        threadPoolExecutor.setCorePoolSize(PluginImpl.getInstance().getNrOfScanThreads());
         threadPoolExecutor.setMaximumPoolSize(PluginImpl.getInstance().getNrOfScanThreads());
+        threadPoolExecutor.setCorePoolSize(PluginImpl.getInstance().getNrOfScanThreads());
 
         logToScanLog(scanLog, "Scanning build for known causes...");
         long start = System.currentTimeMillis();


### PR DESCRIPTION
…uses

Fixes https://issues.jenkins.io/browse/JENKINS-75649.

[ThreadPoolExecutor#setCorePoolSize(int)](https://docs.oracle.com/en/java/javase/21//docs/api/java.base/java/util/concurrent/ThreadPoolExecutor.html#setCorePoolSize(int)) will throw an `IllegalArgumentException` if the core pool size is set to be larger than the maximum pool size.

Since both maximum and core pool size are being set to the same configured number of scan threads, just set the maximum pool size first.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

Ran locally and confirmed the fix.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
