### PR TITLE
Bugfix: Do not display remove button on new failure cause

### DIFF
--- a/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/model/FailureCause/index.groovy
+++ b/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/model/FailureCause/index.groovy
@@ -47,9 +47,11 @@ l.layout(permission: PluginImpl.UPDATE_PERMISSION) {
 
   l.main_panel() {
     l.app_bar(title:"Failure Cause") {
-      a(class: "jenkins-button jenkins-!-destructive-color", href: "../remove?id=" + my.getId(), tooltip: _("Remove this cause")) {
-        l.icon(src:"symbol-trash")
-        text(_("Remove"))
+      if (Util.fixEmpty(my.getId()) != null) {
+        a(class: "jenkins-button jenkins-!-destructive-color", href: "../remove?id=" + my.getId(), tooltip: _("Remove this cause")) {
+          l.icon(src:"symbol-trash")
+          text(_("Remove"))
+        }
       }
     }
 

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/CauseManagementHudsonTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/CauseManagementHudsonTest.java
@@ -181,6 +181,9 @@ class CauseManagementHudsonTest {
         HtmlPage editPage = firstCauseLink.click();
 
         verifyCorrectCauseEditPage(firstCause, editPage);
+
+        assertNotNull(editPage.getFirstByXPath("//a[contains(text(), 'Remove')]"));
+
     }
 
     /**
@@ -203,6 +206,7 @@ class CauseManagementHudsonTest {
                         CauseManagement.NEW_CAUSE_NAME,
                         CauseManagement.NEW_CAUSE_DESCRIPTION, ""),
                 editPage);
+        assertNull(editPage.getFirstByXPath("//a[contains(text(), 'Remove')]"));
     }
 
     /**


### PR DESCRIPTION
Turns out that during #213 I introduced small bug in new/edit Failure Cause page.
When I was moving code around I missed check for Remove button  not visible for new failure cause.

This PR fixes that and adds new asserts in 2 unit tests for this scenario.

### Testing done
- tested locally
- small extension of existing unit tests

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
